### PR TITLE
Fix live scores in-browser (CORS-proxy fallback)

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -16,11 +16,19 @@
 
   const OPENFOOTBALL_URL =
     "https://raw.githubusercontent.com/openfootball/worldcup.json/master/2026/worldcup.json";
-  // Free, no-key live in-match source. Fetched directly from the browser for
-  // ~30s freshness (the server-side Action only refreshes every 5 min — GitHub's
-  // cron minimum). Best-effort: if it's unreachable or blocks cross-origin
-  // requests (CORS), we silently keep the committed data.
-  const LIVE_SOURCE_URL = "https://worldcup26.ir/get/games";
+  // Free, no-key live in-match source, fetched directly from the browser for
+  // ~30s freshness (the server-side Action's cron is best-effort and can stall
+  // for long stretches, so the browser is the real real-time path). worldcup26.ir
+  // does not send CORS headers, so a direct browser fetch is blocked — we try it
+  // first anyway (in case that changes) and then fall back through public CORS
+  // proxies. Best-effort: if all fail we keep the committed data.
+  const LIVE_TARGET = "https://worldcup26.ir/get/games";
+  const LIVE_ENDPOINTS = [
+    LIVE_TARGET,
+    "https://corsproxy.io/?url=" + encodeURIComponent(LIVE_TARGET),
+    "https://api.allorigins.win/raw?url=" + encodeURIComponent(LIVE_TARGET),
+    "https://thingproxy.freeboard.io/fetch/" + LIVE_TARGET,
+  ];
 
   const TEAM_ALIASES = {
     "cote d ivoire": "ivory coast", "cote divoire": "ivory coast",
@@ -101,18 +109,25 @@
   // committed data. worldcup26.ir schema: home_team_name_en / away_team_name_en,
   // home_score / away_score (strings), finished "TRUE"/"FALSE", time_elapsed.
   async function overlayLiveClient(results) {
-    let raw;
-    try {
-      const ctrl = new AbortController();
-      const t = setTimeout(() => ctrl.abort(), 8000);
-      const res = await fetch(LIVE_SOURCE_URL, { cache: "no-store", signal: ctrl.signal });
-      clearTimeout(t);
-      if (!res.ok) return false;
-      raw = await res.json();
-    } catch (e) {
-      return false; // unreachable, timed out, or blocked by CORS — keep committed results
+    // Try each endpoint (direct, then CORS proxies) until one yields games.
+    let games = null;
+    for (const url of LIVE_ENDPOINTS) {
+      try {
+        const ctrl = new AbortController();
+        const t = setTimeout(() => ctrl.abort(), 8000);
+        const res = await fetch(url, { cache: "no-store", signal: ctrl.signal });
+        clearTimeout(t);
+        if (!res.ok) continue;
+        let raw = await res.json();
+        // allorigins (non-/raw) wraps the body in {contents:"<json string>"}
+        if (raw && typeof raw.contents === "string") {
+          try { raw = JSON.parse(raw.contents); } catch (e) { continue; }
+        }
+        const g = Array.isArray(raw) ? raw : (raw.games || raw.matches || raw.data || []);
+        if (g && g.length) { games = g; break; }
+      } catch (e) { /* try next endpoint */ }
     }
-    const games = Array.isArray(raw) ? raw : (raw.games || raw.matches || raw.data || []);
+    if (!games) return false; // all endpoints blocked/unreachable — keep committed results
     const idx = {};
     for (const [key, m] of Object.entries(results.matches)) {
       idx[[normTeam(m.home), normTeam(m.away)].sort().join("|")] = key;

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-19T05:34:30.647186+00:00",
+  "generated_at": "2026-06-19T00:34:34.025373+00:00",
   "matches": {
     "2026-06-11|Mexico|South Africa": {
       "date": "2026-06-11",
@@ -54,12 +54,9 @@
       "away": "South Korea",
       "group": "Group A",
       "ground": "Guadalajara (Zapopan)",
-      "score": [
-        1,
-        0
-      ],
-      "status": "finished",
-      "source": "live"
+      "score": null,
+      "status": "scheduled",
+      "source": "openfootball"
     },
     "2026-06-24|Czech Republic|Mexico": {
       "date": "2026-06-24",

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js"></script>
-  <script src="assets/js/data.js"></script>
-  <script src="assets/js/app.js"></script>
+  <script src="assets/js/scoring.js?v=2"></script>
+  <script src="assets/js/data.js?v=2"></script>
+  <script src="assets/js/app.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Por qué no se actualizó México vs Corea

Dos causas:
1. **El cron de GitHub es "best-effort".** El `*/5` **no corrió durante ~5 h** (entre 00:34 y 05:34 UTC), justo durante el partido. El `results.json` quedó congelado en la foto de las 00:34 (México–Corea todavía "programado").
2. **El navegador no podía traer el vivo:** worldcup26.ir **no manda cabeceras CORS**, así que el fetch directo del navegador se bloqueaba y caía a los datos congelados.

## Arreglo
El navegador ahora intenta el API en vivo directo y, si CORS lo bloquea, **cae a proxies CORS públicos** (corsproxy.io, allorigins, thingproxy) — así el vivo a ~30s funciona sin depender del cron ni de CORS. Maneja el envoltorio `{contents}` de allorigins. Cache-busting de JS (`?v=2`) para que los amigos que ya abrieron el link reciban el código nuevo.

## Verificación
- Sintaxis JS ✓ · `test_scoring.js` ✓
- Lógica de overlay probada con payload simulado ("United States"→USA, 2–1, min 57) ✓
- Nota: no puedo probar CORS/proxies desde el sandbox (egress bloquea esos hosts); se valida en el navegador en el próximo partido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_