### PR TITLE
Reliable live scores via Cloudflare Worker proxy

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -16,19 +16,24 @@
 
   const OPENFOOTBALL_URL =
     "https://raw.githubusercontent.com/openfootball/worldcup.json/master/2026/worldcup.json";
-  // Free, no-key live in-match source, fetched directly from the browser for
-  // ~30s freshness (the server-side Action's cron is best-effort and can stall
-  // for long stretches, so the browser is the real real-time path). worldcup26.ir
-  // does not send CORS headers, so a direct browser fetch is blocked — we try it
-  // first anyway (in case that changes) and then fall back through public CORS
-  // proxies. Best-effort: if all fail we keep the committed data.
+  // Free, no-key live in-match source. worldcup26.ir does NOT send CORS headers,
+  // so a direct browser fetch is blocked. The reliable path is a tiny Cloudflare
+  // Worker (worker/worldcup-proxy.js) whose URL is configured in
+  // data/live-source.json. We try, in order: the configured Worker → direct →
+  // public CORS proxies (unreliable, last resort). Best-effort: if all fail we
+  // keep the committed data. The Worker URL is loaded at runtime into LIVE_PROXY.
   const LIVE_TARGET = "https://worldcup26.ir/get/games";
-  const LIVE_ENDPOINTS = [
-    LIVE_TARGET,
-    "https://corsproxy.io/?url=" + encodeURIComponent(LIVE_TARGET),
-    "https://api.allorigins.win/raw?url=" + encodeURIComponent(LIVE_TARGET),
-    "https://thingproxy.freeboard.io/fetch/" + LIVE_TARGET,
-  ];
+  let LIVE_PROXY = ""; // set from data/live-source.json during load()
+
+  function liveEndpoints() {
+    const enc = encodeURIComponent(LIVE_TARGET);
+    const list = [];
+    if (LIVE_PROXY) list.push(LIVE_PROXY);            // reliable Cloudflare Worker
+    list.push(LIVE_TARGET);                            // direct (works only if CORS opens up)
+    list.push("https://corsproxy.io/?url=" + enc);     // public fallbacks (flaky)
+    list.push("https://api.allorigins.win/raw?url=" + enc);
+    return list;
+  }
 
   const TEAM_ALIASES = {
     "cote d ivoire": "ivory coast", "cote divoire": "ivory coast",
@@ -109,9 +114,9 @@
   // committed data. worldcup26.ir schema: home_team_name_en / away_team_name_en,
   // home_score / away_score (strings), finished "TRUE"/"FALSE", time_elapsed.
   async function overlayLiveClient(results) {
-    // Try each endpoint (direct, then CORS proxies) until one yields games.
+    // Try each endpoint (Worker, then direct, then public proxies) until one yields games.
     let games = null;
-    for (const url of LIVE_ENDPOINTS) {
+    for (const url of liveEndpoints()) {
       try {
         const ctrl = new AbortController();
         const t = setTimeout(() => ctrl.abort(), 8000);
@@ -160,6 +165,11 @@
 
   async function load() {
     const bets = await getJSON("data/bets.json");
+    // Pick up the configured live proxy (Cloudflare Worker) if present.
+    try {
+      const cfg = await getJSON("data/live-source.json");
+      LIVE_PROXY = (cfg && cfg.proxy ? String(cfg.proxy) : "").trim();
+    } catch (e) { LIVE_PROXY = ""; }
     let results;
     try {
       results = await getJSON("data/results.json");

--- a/data/live-source.json
+++ b/data/live-source.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Pega aquí la URL del Cloudflare Worker (worker/worldcup-proxy.js) para los marcadores en vivo. Ej: https://quiniela-live.tu-subdominio.workers.dev . Si queda vacío, el sitio intenta el API directo y proxies públicos como respaldo.",
+  "proxy": ""
+}

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=2"></script>
-  <script src="assets/js/data.js?v=2"></script>
-  <script src="assets/js/app.js?v=2"></script>
+  <script src="assets/js/scoring.js?v=3"></script>
+  <script src="assets/js/data.js?v=3"></script>
+  <script src="assets/js/app.js?v=3"></script>
 </body>
 </html>

--- a/worker/worldcup-proxy.js
+++ b/worker/worldcup-proxy.js
@@ -1,0 +1,53 @@
+/**
+ * Los Reyes Quiniela — live-scores CORS proxy (Cloudflare Worker).
+ *
+ * worldcup26.ir doesn't send CORS headers, so browsers can't fetch it directly.
+ * This tiny Worker fetches it server-side and re-serves the JSON with
+ * `Access-Control-Allow-Origin: *`, so the site can poll it every ~30s.
+ *
+ * Free tier: 100,000 requests/day — far more than this needs.
+ *
+ * Deploy (≈2 min, no CLI needed):
+ *   1. https://dash.cloudflare.com → Workers & Pages → Create → Worker.
+ *   2. Name it e.g. "quiniela-live", click Deploy, then "Edit code".
+ *   3. Replace the sample with THIS file's contents → Deploy.
+ *   4. Copy the URL (https://quiniela-live.<your-subdomain>.workers.dev) and
+ *      put it in data/live-source.json  ->  { "proxy": "<that URL>" }
+ *      (edit it on GitHub, or send it to me and I'll commit it).
+ */
+const UPSTREAM = "https://worldcup26.ir/get/games";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+};
+
+export default {
+  async fetch(request) {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: CORS });
+    }
+    try {
+      const upstream = await fetch(UPSTREAM, {
+        headers: { "User-Agent": "los-reyes-quiniela/1.0", "Accept": "application/json" },
+        // Cache at Cloudflare's edge for 20s so we never hammer the source.
+        cf: { cacheTtl: 20, cacheEverything: true },
+      });
+      const body = await upstream.text();
+      return new Response(body, {
+        status: upstream.status,
+        headers: {
+          ...CORS,
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "no-store",
+        },
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({ error: String(err) }), {
+        status: 502,
+        headers: { ...CORS, "Content-Type": "application/json" },
+      });
+    }
+  },
+};


### PR DESCRIPTION
## Marcadores en vivo confiables (Cloudflare Worker)

Los proxies públicos resultaron poco confiables (allorigins devolvió 400, corsproxy ahora requiere registro). Solución sólida y gratis: un **Cloudflare Worker** que reenvía `worldcup26.ir/get/games` con cabeceras CORS.

- `worker/worldcup-proxy.js` — el Worker (con instrucciones de deploy, ~2 min, sin CLI).
- `data/live-source.json` — `{ "proxy": "<URL del Worker>" }`. El navegador lo lee en runtime.
- `data.js` — intenta en orden: **Worker** → directo → proxies públicos (último recurso).
- Cache-bust de JS a `?v=3`.

Tras desplegar el Worker, solo se pega la URL en `data/live-source.json` (sin tocar código).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_