### PR TITLE
Connect live scores to Cloudflare Worker

### DIFF
--- a/data/live-source.json
+++ b/data/live-source.json
@@ -1,4 +1,4 @@
 {
   "_comment": "Pega aquí la URL del Cloudflare Worker (worker/worldcup-proxy.js) para los marcadores en vivo. Ej: https://quiniela-live.tu-subdominio.workers.dev . Si queda vacío, el sitio intenta el API directo y proxies públicos como respaldo.",
-  "proxy": ""
+  "proxy": "https://quiniela-live.mendez-larregui.workers.dev"
 }


### PR DESCRIPTION
Sets `data/live-source.json` `proxy` to the deployed Cloudflare Worker (`quiniela-live.mendez-larregui.workers.dev`). The browser now pulls live scores through it (~30s, CORS-enabled), with direct/public proxies as fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_