### PR TITLE
Fix mobile load: render instantly, overlay live in background

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -215,11 +215,16 @@
     try {
       const d = await DataLayer.load();
       state.bets = d.bets; state.results = d.results; state.teams = d.teams;
-      render();
+      render(); // paint committed data immediately (fast, same-origin only)
     } catch (e) {
       console.error(e);
       $("#content").innerHTML = `<p class="error">No se pudieron cargar los datos: ${e.message}</p>`;
+      return;
     }
+    // Then overlay live scores in the background and re-render if anything changed.
+    try {
+      if (state.results && await DataLayer.applyLive(state.results)) render();
+    } catch (e) { console.warn("live overlay failed:", e); }
   }
 
   function init() {

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -178,8 +178,11 @@
       console.warn("results.json unavailable, falling back to openfootball:", e);
       results = normalizeOpenfootball(await getJSON(OPENFOOTBALL_URL));
     }
-    await overlayLiveClient(results); // ~30s live refresh, best-effort
     applyClock(results);
+    // NOTE: the live overlay is intentionally NOT awaited here — it's an
+    // external network call and would block first paint on slow phones. The app
+    // renders committed data immediately, then calls applyLive() to fill in live
+    // scores and re-renders.
 
     // Attach team metadata (Spanish name + flag); tolerate a missing file.
     let teams = {};
@@ -188,5 +191,13 @@
     return { bets, results, teams };
   }
 
-  global.DataLayer = { load };
+  // Overlay live scores onto already-loaded results, then re-apply the clock.
+  // Returns true if anything changed (so the caller can re-render). Best-effort.
+  async function applyLive(results) {
+    const changed = await overlayLiveClient(results);
+    applyClock(results);
+    return changed;
+  }
+
+  global.DataLayer = { load, applyLive };
 })(typeof window !== "undefined" ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=3"></script>
-  <script src="assets/js/data.js?v=3"></script>
-  <script src="assets/js/app.js?v=3"></script>
+  <script src="assets/js/scoring.js?v=4"></script>
+  <script src="assets/js/data.js?v=4"></script>
+  <script src="assets/js/app.js?v=4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Arregla "no carga en el celular"

En conexiones lentas el sitio parecía no cargar porque el primer render **esperaba** la llamada externa de marcadores en vivo (hasta varios segundos, peor caso ~30s recorriendo respaldos).

Ahora `load()` regresa los datos committeados (solo mismo-origen, rápido) y la app **pinta de inmediato**; luego `DataLayer.applyLive()` trae el vivo en segundo plano y re-renderiza si cambió algo. Cache-bust de JS a `?v=4`.

Verificación: sintaxis JS ✓, `test_scoring.js` ✓, un solo `load()` + `applyLive` exportado ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_