### PR TITLE
Remove direct browser fetch (clean up console errors)

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -16,21 +16,22 @@
 
   const OPENFOOTBALL_URL =
     "https://raw.githubusercontent.com/openfootball/worldcup.json/master/2026/worldcup.json";
-  // Free, no-key live in-match source. worldcup26.ir does NOT send CORS headers,
-  // so a direct browser fetch is blocked. The reliable path is a tiny Cloudflare
-  // Worker (worker/worldcup-proxy.js) whose URL is configured in
-  // data/live-source.json. We try, in order: the configured Worker → direct →
-  // public CORS proxies (unreliable, last resort). Best-effort: if all fail we
-  // keep the committed data. The Worker URL is loaded at runtime into LIVE_PROXY.
+  // Free, no-key live in-match source. worldcup26.ir does NOT send CORS headers
+  // (and refuses direct cross-origin connections), so the browser never hits it
+  // directly — that only spams the console with ERR_CONNECTION_RESET. The reliable
+  // path is a tiny Cloudflare Worker (worker/worldcup-proxy.js) whose URL is in
+  // data/live-source.json (loaded at runtime into LIVE_PROXY). Public CORS proxies
+  // are kept only as a flaky last resort. Best-effort: if all fail we keep the
+  // committed data. (The server-side scripts/fetch_results.py DOES use the direct
+  // URL, where it works fine.)
   const LIVE_TARGET = "https://worldcup26.ir/get/games";
   let LIVE_PROXY = ""; // set from data/live-source.json during load()
 
   function liveEndpoints() {
     const enc = encodeURIComponent(LIVE_TARGET);
     const list = [];
-    if (LIVE_PROXY) list.push(LIVE_PROXY);            // reliable Cloudflare Worker
-    list.push(LIVE_TARGET);                            // direct (works only if CORS opens up)
-    list.push("https://corsproxy.io/?url=" + enc);     // public fallbacks (flaky)
+    if (LIVE_PROXY) list.push(LIVE_PROXY);             // reliable Cloudflare Worker (primary)
+    list.push("https://corsproxy.io/?url=" + enc);     // public fallbacks (flaky, last resort)
     list.push("https://api.allorigins.win/raw?url=" + enc);
     return list;
   }

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=4"></script>
-  <script src="assets/js/data.js?v=4"></script>
-  <script src="assets/js/app.js?v=4"></script>
+  <script src="assets/js/scoring.js?v=5"></script>
+  <script src="assets/js/data.js?v=5"></script>
+  <script src="assets/js/app.js?v=5"></script>
 </body>
 </html>


### PR DESCRIPTION
El fetch directo a worldcup26.ir desde el navegador siempre falla (`ERR_CONNECTION_RESET`) y solo ensucia la consola; el Worker ya lo maneja. El navegador ahora usa **Worker primero**, luego proxies públicos. El script del servidor (`fetch_results.py`) sigue usando la URL directa (ahí sí funciona). Cache-bust a `?v=5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_