### PR TITLE
Rank by total points only (equal points tie)

### DIFF
--- a/assets/js/scoring.js
+++ b/assets/js/scoring.js
@@ -56,6 +56,9 @@
       }
     }
 
+    // Display order: by points; exact/outcome only break the visual order, NOT
+    // the rank. Ranking is by TOTAL POINTS only — equal points = same place
+    // (and they split the prize for those places).
     rows.sort(
       (a, b) =>
         b.points - a.points ||
@@ -63,11 +66,9 @@
         b.outcome - a.outcome ||
         a.player.localeCompare(b.player, "es")
     );
-    // Assign ranks (ties share a rank).
     let rank = 0, prev = null;
     rows.forEach((r, i) => {
-      const sig = `${r.points}|${r.exact}|${r.outcome}`;
-      if (sig !== prev) { rank = i + 1; prev = sig; }
+      if (r.points !== prev) { rank = i + 1; prev = r.points; }
       r.rank = rank;
     });
     return rows;

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=6"></script>
-  <script src="assets/js/data.js?v=6"></script>
-  <script src="assets/js/app.js?v=6"></script>
+  <script src="assets/js/scoring.js?v=7"></script>
+  <script src="assets/js/data.js?v=7"></script>
+  <script src="assets/js/app.js?v=7"></script>
 </body>
 </html>


### PR DESCRIPTION
El ranking desempataba por # de marcadores exactos, así que dos jugadores con los **mismos puntos** quedaban en 2º y 3º en lugar de empatar. Ahora el lugar se define **solo por puntos totales**; exactos/resultados quedan solo como orden visual e info. Los empatados comparten lugar y se reparten el premio combinado (ej: dos con mismos puntos en 2º → 2º+3º = $1,200 c/u). Cache-bust a `?v=7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_