### PR TITLE
Revert prize rule to common practice (combined occupied places)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,22 +6,29 @@
   const DAYS = ["domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado"];
   const MONTHS = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
 
-  // Prize pot (MXN). Places are by total points (dense rank). Each place divides
-  // ITS OWN prize equally among everyone in that place — e.g. with 4 in 1st,
-  // 5 in 2nd, 6 in 3rd: each gets 3600/4, 1500/5, 900/6. Places beyond 3rd: $0.
+  // Prize pot (MXN). Common practice: ties split, in equal parts, the COMBINED
+  // prize of the places they occupy (places beyond 3rd pay 0). E.g. 3 tied for
+  // 3rd → each gets POT*0.15/3 = $300; 2 tied for 1st → each (60%+25%)/2 = $2,550.
   const POT = 6000;
   const PLACE_PCT = { 1: 0.60, 2: 0.25, 3: 0.15 };
   const mxn = new Intl.NumberFormat("es-MX", { style: "currency", currency: "MXN", maximumFractionDigits: 0 });
   const fmtMXN = (n) => mxn.format(Math.round(n));
 
-  // Set r.prize: each rank (place) splits its own pot share among its members.
+  // Set r.prize: tied players (same competition rank) occupy places rank..rank+k-1
+  // and split the combined prize of those places equally.
   function assignPrizes(rows) {
-    const counts = {};
-    rows.forEach((r) => { counts[r.rank] = (counts[r.rank] || 0) + 1; });
-    rows.forEach((r) => {
-      const pct = PLACE_PCT[r.rank] || 0;
-      r.prize = pct ? (POT * pct) / counts[r.rank] : 0;
-    });
+    let i = 0;
+    while (i < rows.length) {
+      const rank = rows[i].rank;
+      let j = i;
+      while (j < rows.length && rows[j].rank === rank) j++;
+      const k = j - i; // players tied at this rank
+      let sumPct = 0;
+      for (let p = rank; p < rank + k; p++) sumPct += PLACE_PCT[p] || 0;
+      const each = (POT * sumPct) / k;
+      for (let t = i; t < j; t++) rows[t].prize = each;
+      i = j;
+    }
     return rows;
   }
 

--- a/assets/js/scoring.js
+++ b/assets/js/scoring.js
@@ -67,8 +67,8 @@
         a.player.localeCompare(b.player, "es")
     );
     let rank = 0, prev = null;
-    rows.forEach((r) => {
-      if (r.points !== prev) { rank += 1; prev = r.points; } // dense rank: 1º,2º,3º by distinct point totals
+    rows.forEach((r, i) => {
+      if (r.points !== prev) { rank = i + 1; prev = r.points; } // competition rank: ties share, next skips (1,1,3…)
       r.rank = rank;
     });
     return rows;

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=8"></script>
-  <script src="assets/js/data.js?v=8"></script>
-  <script src="assets/js/app.js?v=8"></script>
+  <script src="assets/js/scoring.js?v=9"></script>
+  <script src="assets/js/data.js?v=9"></script>
+  <script src="assets/js/app.js?v=9"></script>
 </body>
 </html>


### PR DESCRIPTION
Regresa a la práctica común: **ranking de competencia** (empatados comparten lugar y el siguiente salta) y los empatados **se reparten el premio combinado de los lugares que ocupan** (4º+ paga 0). Ej: 3 empatados en 3º → $300 c/u; 2 en 1º → $2,550 c/u + 3º $900. Cache-bust a `?v=9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_