### PR TITLE
Add Grupos tab: group standings + knockout bracket

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -151,6 +151,37 @@ body > * { position: relative; z-index: 1; }
 .jmatch .flag { font-size: 1.1rem; }
 .jvs { font-weight: 800; color: var(--muted); padding: 0 4px; }
 
+/* Grupos + Bracket */
+.sechdr { color: var(--gold); font-size: 1.05rem; margin: 22px 0 6px; border-bottom: 1px solid var(--gold-deep); padding-bottom: 5px; }
+.groupgrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+.grouptable { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 8px 10px 10px; }
+.ghdr { margin: 2px 0 8px; font-size: 0.92rem; color: var(--txt); }
+.gtbl { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.gtbl th { color: var(--muted); font-weight: 600; text-align: center; padding: 3px 4px; border-bottom: 1px solid var(--line); }
+.gtbl td { text-align: center; padding: 5px 4px; border-bottom: 1px solid rgba(255,255,255,0.05); }
+.gtbl td.rank { color: var(--muted); width: 18px; }
+.gtbl td.gteam { text-align: left; }
+.gtbl td.gpts { font-weight: 800; color: var(--gold); }
+.gtbl tr.q1 td.rank { box-shadow: inset 3px 0 0 var(--p2); }   /* top 2 qualify */
+.gtbl tr.q3 td.rank { box-shadow: inset 3px 0 0 var(--p1); }   /* 3rd: maybe */
+.gtbl .team .tname { display: inline; font-weight: 600; font-size: 0.82rem; }
+.gtbl .flag { font-size: 1rem; }
+
+.team.ph { display: inline-flex; align-items: center; }
+.phcode { color: var(--muted); font-weight: 700; font-size: 0.8rem; background: var(--bg2); border: 1px dashed var(--line); border-radius: 6px; padding: 1px 6px; }
+
+.bracket { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; align-items: start; }
+.round { background: rgba(0,0,0,0.15); border: 1px solid var(--line); border-radius: var(--radius); padding: 8px 10px 10px; }
+.rhdr { margin: 2px 0 8px; font-size: 0.9rem; color: var(--gold); text-align: center; }
+.tie { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 8px 10px; margin-bottom: 8px; }
+.tiehead { display: flex; align-items: center; gap: 6px; font-size: 0.7rem; color: var(--muted); margin-bottom: 6px; }
+.tiehead .tdate { margin-right: auto; text-transform: capitalize; }
+.tierow { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 6px; }
+.tierow .team:last-child { justify-content: flex-end; }
+.tscore { font-weight: 800; min-width: 42px; text-align: center; color: var(--muted); }
+.tscore.finished, .tscore.live { color: var(--txt); }
+.tscore.live { color: var(--live); }
+
 .foot { text-align: center; padding: 20px; color: var(--muted); font-size: 0.75rem; }
 .foot a { color: var(--accent); }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -230,6 +230,104 @@
     return wrap;
   }
 
+  /* ---------- Grupos + Bracket ---------- */
+
+  // Compute group tables from finished group-stage matches (3-1-0 points).
+  function computeGroupTables() {
+    const groups = {};
+    for (const m of Object.values(state.results.matches)) {
+      const g = m.group;
+      if (!g || g.indexOf("Group") !== 0) continue;
+      groups[g] = groups[g] || {};
+      for (const t of [m.home, m.away]) {
+        groups[g][t] = groups[g][t] || { team: t, pj: 0, g: 0, e: 0, p: 0, gf: 0, ga: 0, pts: 0 };
+      }
+      if (m.status === "finished" && m.score) {
+        const [hs, as] = m.score, H = groups[g][m.home], A = groups[g][m.away];
+        H.pj++; A.pj++; H.gf += hs; H.ga += as; A.gf += as; A.ga += hs;
+        if (hs > as) { H.g++; A.p++; H.pts += 3; }
+        else if (hs < as) { A.g++; H.p++; A.pts += 3; }
+        else { H.e++; A.e++; H.pts++; A.pts++; }
+      }
+    }
+    const out = {};
+    Object.keys(groups).sort().forEach((g) => {
+      out[g] = Object.values(groups[g]).sort((a, b) =>
+        b.pts - a.pts || (b.gf - b.ga) - (a.gf - a.ga) || b.gf - a.gf ||
+        a.team.localeCompare(b.team, "es"));
+    });
+    return out;
+  }
+
+  // A knockout slot is a real team (flag + name) or a placeholder code (e.g. "2A").
+  function koTeamHTML(name) {
+    if (state.teams[name]) return teamHTML(name);
+    return `<span class="team ph"><span class="phcode">${name || "?"}</span></span>`;
+  }
+
+  const KO_ROUNDS = [
+    ["Round of 32", "Dieciseisavos de final"],
+    ["Round of 16", "Octavos de final"],
+    ["Quarter-final", "Cuartos de final"],
+    ["Semi-final", "Semifinales"],
+    ["Match for third place", "Tercer lugar"],
+    ["Final", "Final"],
+  ];
+
+  function renderGrupos() {
+    const wrap = el("div");
+
+    // --- Group standings ---
+    wrap.appendChild(el("h2", "sechdr", "Fase de Grupos"));
+    wrap.appendChild(el("p", "hint", "Clasifican los 2 primeros de cada grupo (y los 8 mejores terceros). 3 pts victoria · 1 empate."));
+    const grid = el("div", "groupgrid");
+    const tables = computeGroupTables();
+    Object.keys(tables).forEach((g) => {
+      const box = el("div", "grouptable");
+      box.appendChild(el("h3", "ghdr", g.replace("Group", "Grupo")));
+      const t = el("table", "gtbl");
+      t.innerHTML = `<thead><tr><th>#</th><th>Equipo</th><th>PJ</th><th>G</th><th>E</th><th>P</th><th>DG</th><th>Pts</th></tr></thead>`;
+      const tb = el("tbody");
+      tables[g].forEach((r, idx) => {
+        const cls = idx < 2 ? "q1" : idx === 2 ? "q3" : "";
+        const dg = r.gf - r.ga;
+        const tr = el("tr", cls);
+        tr.innerHTML = `<td class="rank">${idx + 1}</td>
+          <td class="gteam">${koTeamHTML(r.team)}</td>
+          <td>${r.pj}</td><td>${r.g}</td><td>${r.e}</td><td>${r.p}</td>
+          <td>${dg > 0 ? "+" + dg : dg}</td><td class="gpts">${r.pts}</td>`;
+        tb.appendChild(tr);
+      });
+      t.appendChild(tb);
+      box.appendChild(t);
+      grid.appendChild(box);
+    });
+    wrap.appendChild(grid);
+
+    // --- Knockout bracket (round by round) ---
+    wrap.appendChild(el("h2", "sechdr", "Eliminatorias"));
+    const allKo = Object.values(state.results.matches).filter((m) => m.round && (!m.group || m.group.indexOf("Group") !== 0));
+    const bracket = el("div", "bracket");
+    KO_ROUNDS.forEach(([en, es]) => {
+      const ms = allKo.filter((m) => m.round === en)
+        .sort((a, b) => (Date.parse(a.kickoff_utc) || 0) - (Date.parse(b.kickoff_utc) || 0));
+      if (!ms.length) return;
+      const col = el("div", "round");
+      col.appendChild(el("h3", "rhdr", es));
+      ms.forEach((m) => {
+        const score = m.score ? `${m.score[0]}–${m.score[1]}` : "vs";
+        const tie = el("div", "tie");
+        tie.innerHTML = `
+          <div class="tiehead"><span class="tdate">${fmtDay(m.date)} · ${fmtKickoffTime(m)}</span>${statusBadge(m)}</div>
+          <div class="tierow">${koTeamHTML(m.home)}<span class="tscore ${m.status}">${score}</span>${koTeamHTML(m.away)}</div>`;
+        col.appendChild(tie);
+      });
+      bracket.appendChild(col);
+    });
+    wrap.appendChild(bracket);
+    return wrap;
+  }
+
   /* ---------- Shell ---------- */
 
   function switchView(v) { state.view = v; render(); window.scrollTo(0, 0); }
@@ -239,6 +337,7 @@
     main.innerHTML = "";
     if (state.view === "posiciones") main.appendChild(renderPosiciones());
     else if (state.view === "partidos") main.appendChild(renderPartidos());
+    else if (state.view === "grupos") main.appendChild(renderGrupos());
     else main.appendChild(renderJugador());
 
     document.querySelectorAll(".tab").forEach((t) =>

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -82,7 +82,7 @@
       const ft = m.score && m.score.ft;
       matches[`${date}|${home}|${away}`] = {
         date, time: m.time, kickoff_utc: kickoffUtc(date, m.time),
-        home, away, group: m.group, ground: m.ground,
+        home, away, group: m.group, round: m.round, ground: m.ground,
         score: ft && ft.length === 2 ? [ft[0], ft[1]] : null,
         status: ft && ft.length === 2 ? "finished" : "scheduled",
         source: "openfootball",

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-19T18:18:13.021498+00:00",
+  "generated_at": "2026-06-19T19:34:55.005277+00:00",
   "matches": {
     "2026-06-11|Mexico|South Africa": {
       "date": "2026-06-11",
@@ -8,13 +8,14 @@
       "home": "Mexico",
       "away": "South Africa",
       "group": "Group A",
+      "round": "Matchday 1",
       "ground": "Mexico City",
       "score": [
         2,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-11|South Korea|Czech Republic": {
       "date": "2026-06-11",
@@ -23,13 +24,14 @@
       "home": "South Korea",
       "away": "Czech Republic",
       "group": "Group A",
+      "round": "Matchday 1",
       "ground": "Guadalajara (Zapopan)",
       "score": [
         2,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Czech Republic|South Africa": {
       "date": "2026-06-18",
@@ -38,13 +40,14 @@
       "home": "Czech Republic",
       "away": "South Africa",
       "group": "Group A",
+      "round": "Matchday 8",
       "ground": "Atlanta",
       "score": [
         1,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Mexico|South Korea": {
       "date": "2026-06-18",
@@ -53,13 +56,14 @@
       "home": "Mexico",
       "away": "South Korea",
       "group": "Group A",
+      "round": "Matchday 8",
       "ground": "Guadalajara (Zapopan)",
       "score": [
         1,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Czech Republic|Mexico": {
       "date": "2026-06-24",
@@ -68,6 +72,7 @@
       "home": "Czech Republic",
       "away": "Mexico",
       "group": "Group A",
+      "round": "Matchday 14",
       "ground": "Mexico City",
       "score": null,
       "status": "scheduled",
@@ -80,6 +85,7 @@
       "home": "South Africa",
       "away": "South Korea",
       "group": "Group A",
+      "round": "Matchday 14",
       "ground": "Monterrey (Guadalupe)",
       "score": null,
       "status": "scheduled",
@@ -92,13 +98,14 @@
       "home": "Canada",
       "away": "Bosnia & Herzegovina",
       "group": "Group B",
+      "round": "Matchday 2",
       "ground": "Toronto",
       "score": [
         1,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Qatar|Switzerland": {
       "date": "2026-06-13",
@@ -107,13 +114,14 @@
       "home": "Qatar",
       "away": "Switzerland",
       "group": "Group B",
+      "round": "Matchday 3",
       "ground": "San Francisco Bay Area (Santa Clara)",
       "score": [
         1,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Switzerland|Bosnia & Herzegovina": {
       "date": "2026-06-18",
@@ -122,13 +130,14 @@
       "home": "Switzerland",
       "away": "Bosnia & Herzegovina",
       "group": "Group B",
+      "round": "Matchday 8",
       "ground": "Los Angeles (Inglewood)",
       "score": [
         4,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Canada|Qatar": {
       "date": "2026-06-18",
@@ -137,13 +146,14 @@
       "home": "Canada",
       "away": "Qatar",
       "group": "Group B",
+      "round": "Matchday 8",
       "ground": "Vancouver",
       "score": [
         6,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Switzerland|Canada": {
       "date": "2026-06-24",
@@ -152,6 +162,7 @@
       "home": "Switzerland",
       "away": "Canada",
       "group": "Group B",
+      "round": "Matchday 14",
       "ground": "Vancouver",
       "score": null,
       "status": "scheduled",
@@ -164,6 +175,7 @@
       "home": "Bosnia & Herzegovina",
       "away": "Qatar",
       "group": "Group B",
+      "round": "Matchday 14",
       "ground": "Seattle",
       "score": null,
       "status": "scheduled",
@@ -176,13 +188,14 @@
       "home": "Brazil",
       "away": "Morocco",
       "group": "Group C",
+      "round": "Matchday 3",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": [
         1,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Haiti|Scotland": {
       "date": "2026-06-13",
@@ -191,13 +204,14 @@
       "home": "Haiti",
       "away": "Scotland",
       "group": "Group C",
+      "round": "Matchday 3",
       "ground": "Boston (Foxborough)",
       "score": [
         0,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|Scotland|Morocco": {
       "date": "2026-06-19",
@@ -206,6 +220,7 @@
       "home": "Scotland",
       "away": "Morocco",
       "group": "Group C",
+      "round": "Matchday 9",
       "ground": "Boston (Foxborough)",
       "score": null,
       "status": "scheduled",
@@ -218,6 +233,7 @@
       "home": "Brazil",
       "away": "Haiti",
       "group": "Group C",
+      "round": "Matchday 9",
       "ground": "Philadelphia",
       "score": null,
       "status": "scheduled",
@@ -230,6 +246,7 @@
       "home": "Scotland",
       "away": "Brazil",
       "group": "Group C",
+      "round": "Matchday 14",
       "ground": "Miami (Miami Gardens)",
       "score": null,
       "status": "scheduled",
@@ -242,6 +259,7 @@
       "home": "Morocco",
       "away": "Haiti",
       "group": "Group C",
+      "round": "Matchday 14",
       "ground": "Atlanta",
       "score": null,
       "status": "scheduled",
@@ -254,13 +272,14 @@
       "home": "USA",
       "away": "Paraguay",
       "group": "Group D",
+      "round": "Matchday 2",
       "ground": "Los Angeles (Inglewood)",
       "score": [
         4,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Australia|Turkey": {
       "date": "2026-06-13",
@@ -269,13 +288,14 @@
       "home": "Australia",
       "away": "Turkey",
       "group": "Group D",
+      "round": "Matchday 3",
       "ground": "Vancouver",
       "score": [
         2,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|USA|Australia": {
       "date": "2026-06-19",
@@ -284,6 +304,7 @@
       "home": "USA",
       "away": "Australia",
       "group": "Group D",
+      "round": "Matchday 9",
       "ground": "Seattle",
       "score": null,
       "status": "scheduled",
@@ -296,6 +317,7 @@
       "home": "Turkey",
       "away": "Paraguay",
       "group": "Group D",
+      "round": "Matchday 9",
       "ground": "San Francisco Bay Area (Santa Clara)",
       "score": null,
       "status": "scheduled",
@@ -308,6 +330,7 @@
       "home": "Turkey",
       "away": "USA",
       "group": "Group D",
+      "round": "Matchday 15",
       "ground": "Los Angeles (Inglewood)",
       "score": null,
       "status": "scheduled",
@@ -320,6 +343,7 @@
       "home": "Paraguay",
       "away": "Australia",
       "group": "Group D",
+      "round": "Matchday 15",
       "ground": "San Francisco Bay Area (Santa Clara)",
       "score": null,
       "status": "scheduled",
@@ -332,13 +356,14 @@
       "home": "Germany",
       "away": "Curaçao",
       "group": "Group E",
+      "round": "Matchday 4",
       "ground": "Houston",
       "score": [
         7,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Ivory Coast|Ecuador": {
       "date": "2026-06-14",
@@ -347,13 +372,14 @@
       "home": "Ivory Coast",
       "away": "Ecuador",
       "group": "Group E",
+      "round": "Matchday 4",
       "ground": "Philadelphia",
       "score": [
         1,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Germany|Ivory Coast": {
       "date": "2026-06-20",
@@ -362,6 +388,7 @@
       "home": "Germany",
       "away": "Ivory Coast",
       "group": "Group E",
+      "round": "Matchday 10",
       "ground": "Toronto",
       "score": null,
       "status": "scheduled",
@@ -374,6 +401,7 @@
       "home": "Ecuador",
       "away": "Curaçao",
       "group": "Group E",
+      "round": "Matchday 10",
       "ground": "Kansas City",
       "score": null,
       "status": "scheduled",
@@ -386,6 +414,7 @@
       "home": "Curaçao",
       "away": "Ivory Coast",
       "group": "Group E",
+      "round": "Matchday 15",
       "ground": "Philadelphia",
       "score": null,
       "status": "scheduled",
@@ -398,6 +427,7 @@
       "home": "Ecuador",
       "away": "Germany",
       "group": "Group E",
+      "round": "Matchday 15",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
       "status": "scheduled",
@@ -410,13 +440,14 @@
       "home": "Netherlands",
       "away": "Japan",
       "group": "Group F",
+      "round": "Matchday 4",
       "ground": "Dallas (Arlington)",
       "score": [
         2,
         2
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Sweden|Tunisia": {
       "date": "2026-06-14",
@@ -425,13 +456,14 @@
       "home": "Sweden",
       "away": "Tunisia",
       "group": "Group F",
+      "round": "Matchday 4",
       "ground": "Monterrey (Guadalupe)",
       "score": [
         5,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Netherlands|Sweden": {
       "date": "2026-06-20",
@@ -440,6 +472,7 @@
       "home": "Netherlands",
       "away": "Sweden",
       "group": "Group F",
+      "round": "Matchday 10",
       "ground": "Houston",
       "score": null,
       "status": "scheduled",
@@ -452,6 +485,7 @@
       "home": "Tunisia",
       "away": "Japan",
       "group": "Group F",
+      "round": "Matchday 10",
       "ground": "Monterrey (Guadalupe)",
       "score": null,
       "status": "scheduled",
@@ -464,6 +498,7 @@
       "home": "Japan",
       "away": "Sweden",
       "group": "Group F",
+      "round": "Matchday 15",
       "ground": "Dallas (Arlington)",
       "score": null,
       "status": "scheduled",
@@ -476,6 +511,7 @@
       "home": "Tunisia",
       "away": "Netherlands",
       "group": "Group F",
+      "round": "Matchday 15",
       "ground": "Kansas City",
       "score": null,
       "status": "scheduled",
@@ -488,13 +524,14 @@
       "home": "Belgium",
       "away": "Egypt",
       "group": "Group G",
+      "round": "Matchday 5",
       "ground": "Seattle",
       "score": [
         1,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Iran|New Zealand": {
       "date": "2026-06-15",
@@ -503,13 +540,14 @@
       "home": "Iran",
       "away": "New Zealand",
       "group": "Group G",
+      "round": "Matchday 5",
       "ground": "Los Angeles (Inglewood)",
       "score": [
         2,
         2
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Belgium|Iran": {
       "date": "2026-06-21",
@@ -518,6 +556,7 @@
       "home": "Belgium",
       "away": "Iran",
       "group": "Group G",
+      "round": "Matchday 11",
       "ground": "Los Angeles (Inglewood)",
       "score": null,
       "status": "scheduled",
@@ -530,6 +569,7 @@
       "home": "New Zealand",
       "away": "Egypt",
       "group": "Group G",
+      "round": "Matchday 11",
       "ground": "Vancouver",
       "score": null,
       "status": "scheduled",
@@ -542,6 +582,7 @@
       "home": "Egypt",
       "away": "Iran",
       "group": "Group G",
+      "round": "Matchday 16",
       "ground": "Seattle",
       "score": null,
       "status": "scheduled",
@@ -554,6 +595,7 @@
       "home": "New Zealand",
       "away": "Belgium",
       "group": "Group G",
+      "round": "Matchday 16",
       "ground": "Vancouver",
       "score": null,
       "status": "scheduled",
@@ -566,13 +608,14 @@
       "home": "Spain",
       "away": "Cape Verde",
       "group": "Group H",
+      "round": "Matchday 5",
       "ground": "Atlanta",
       "score": [
         0,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Saudi Arabia|Uruguay": {
       "date": "2026-06-15",
@@ -581,13 +624,14 @@
       "home": "Saudi Arabia",
       "away": "Uruguay",
       "group": "Group H",
+      "round": "Matchday 5",
       "ground": "Miami (Miami Gardens)",
       "score": [
         1,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Spain|Saudi Arabia": {
       "date": "2026-06-21",
@@ -596,6 +640,7 @@
       "home": "Spain",
       "away": "Saudi Arabia",
       "group": "Group H",
+      "round": "Matchday 11",
       "ground": "Atlanta",
       "score": null,
       "status": "scheduled",
@@ -608,6 +653,7 @@
       "home": "Uruguay",
       "away": "Cape Verde",
       "group": "Group H",
+      "round": "Matchday 11",
       "ground": "Miami (Miami Gardens)",
       "score": null,
       "status": "scheduled",
@@ -620,6 +666,7 @@
       "home": "Cape Verde",
       "away": "Saudi Arabia",
       "group": "Group H",
+      "round": "Matchday 16",
       "ground": "Houston",
       "score": null,
       "status": "scheduled",
@@ -632,6 +679,7 @@
       "home": "Uruguay",
       "away": "Spain",
       "group": "Group H",
+      "round": "Matchday 16",
       "ground": "Guadalajara (Zapopan)",
       "score": null,
       "status": "scheduled",
@@ -644,13 +692,14 @@
       "home": "France",
       "away": "Senegal",
       "group": "Group I",
+      "round": "Matchday 6",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": [
         3,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Iraq|Norway": {
       "date": "2026-06-16",
@@ -659,13 +708,14 @@
       "home": "Iraq",
       "away": "Norway",
       "group": "Group I",
+      "round": "Matchday 6",
       "ground": "Boston (Foxborough)",
       "score": [
         1,
         4
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|France|Iraq": {
       "date": "2026-06-22",
@@ -674,6 +724,7 @@
       "home": "France",
       "away": "Iraq",
       "group": "Group I",
+      "round": "Matchday 12",
       "ground": "Philadelphia",
       "score": null,
       "status": "scheduled",
@@ -686,6 +737,7 @@
       "home": "Norway",
       "away": "Senegal",
       "group": "Group I",
+      "round": "Matchday 12",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
       "status": "scheduled",
@@ -698,6 +750,7 @@
       "home": "Norway",
       "away": "France",
       "group": "Group I",
+      "round": "Matchday 16",
       "ground": "Boston (Foxborough)",
       "score": null,
       "status": "scheduled",
@@ -710,6 +763,7 @@
       "home": "Senegal",
       "away": "Iraq",
       "group": "Group I",
+      "round": "Matchday 16",
       "ground": "Toronto",
       "score": null,
       "status": "scheduled",
@@ -722,13 +776,14 @@
       "home": "Argentina",
       "away": "Algeria",
       "group": "Group J",
+      "round": "Matchday 6",
       "ground": "Kansas City",
       "score": [
         3,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Austria|Jordan": {
       "date": "2026-06-16",
@@ -737,13 +792,14 @@
       "home": "Austria",
       "away": "Jordan",
       "group": "Group J",
+      "round": "Matchday 6",
       "ground": "San Francisco Bay Area (Santa Clara)",
       "score": [
         3,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|Argentina|Austria": {
       "date": "2026-06-22",
@@ -752,6 +808,7 @@
       "home": "Argentina",
       "away": "Austria",
       "group": "Group J",
+      "round": "Matchday 12",
       "ground": "Dallas (Arlington)",
       "score": null,
       "status": "scheduled",
@@ -764,6 +821,7 @@
       "home": "Jordan",
       "away": "Algeria",
       "group": "Group J",
+      "round": "Matchday 12",
       "ground": "San Francisco Bay Area (Santa Clara)",
       "score": null,
       "status": "scheduled",
@@ -776,6 +834,7 @@
       "home": "Algeria",
       "away": "Austria",
       "group": "Group J",
+      "round": "Matchday 17",
       "ground": "Kansas City",
       "score": null,
       "status": "scheduled",
@@ -788,6 +847,7 @@
       "home": "Jordan",
       "away": "Argentina",
       "group": "Group J",
+      "round": "Matchday 17",
       "ground": "Dallas (Arlington)",
       "score": null,
       "status": "scheduled",
@@ -800,13 +860,14 @@
       "home": "Portugal",
       "away": "DR Congo",
       "group": "Group K",
+      "round": "Matchday 7",
       "ground": "Houston",
       "score": [
         1,
         1
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Uzbekistan|Colombia": {
       "date": "2026-06-17",
@@ -815,13 +876,14 @@
       "home": "Uzbekistan",
       "away": "Colombia",
       "group": "Group K",
+      "round": "Matchday 7",
       "ground": "Mexico City",
       "score": [
         1,
         3
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|Portugal|Uzbekistan": {
       "date": "2026-06-23",
@@ -830,6 +892,7 @@
       "home": "Portugal",
       "away": "Uzbekistan",
       "group": "Group K",
+      "round": "Matchday 13",
       "ground": "Houston",
       "score": null,
       "status": "scheduled",
@@ -842,6 +905,7 @@
       "home": "Colombia",
       "away": "DR Congo",
       "group": "Group K",
+      "round": "Matchday 13",
       "ground": "Guadalajara (Zapopan)",
       "score": null,
       "status": "scheduled",
@@ -854,6 +918,7 @@
       "home": "Colombia",
       "away": "Portugal",
       "group": "Group K",
+      "round": "Matchday 17",
       "ground": "Miami (Miami Gardens)",
       "score": null,
       "status": "scheduled",
@@ -866,6 +931,7 @@
       "home": "DR Congo",
       "away": "Uzbekistan",
       "group": "Group K",
+      "round": "Matchday 17",
       "ground": "Atlanta",
       "score": null,
       "status": "scheduled",
@@ -878,13 +944,14 @@
       "home": "England",
       "away": "Croatia",
       "group": "Group L",
+      "round": "Matchday 7",
       "ground": "Dallas (Arlington)",
       "score": [
         4,
         2
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Ghana|Panama": {
       "date": "2026-06-17",
@@ -893,13 +960,14 @@
       "home": "Ghana",
       "away": "Panama",
       "group": "Group L",
+      "round": "Matchday 7",
       "ground": "Toronto",
       "score": [
         1,
         0
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|England|Ghana": {
       "date": "2026-06-23",
@@ -908,6 +976,7 @@
       "home": "England",
       "away": "Ghana",
       "group": "Group L",
+      "round": "Matchday 13",
       "ground": "Boston (Foxborough)",
       "score": null,
       "status": "scheduled",
@@ -920,6 +989,7 @@
       "home": "Panama",
       "away": "Croatia",
       "group": "Group L",
+      "round": "Matchday 13",
       "ground": "Toronto",
       "score": null,
       "status": "scheduled",
@@ -932,6 +1002,7 @@
       "home": "Panama",
       "away": "England",
       "group": "Group L",
+      "round": "Matchday 17",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
       "status": "scheduled",
@@ -944,6 +1015,7 @@
       "home": "Croatia",
       "away": "Ghana",
       "group": "Group L",
+      "round": "Matchday 17",
       "ground": "Philadelphia",
       "score": null,
       "status": "scheduled",
@@ -956,6 +1028,7 @@
       "home": "2A",
       "away": "2B",
       "group": null,
+      "round": "Round of 32",
       "ground": "Los Angeles (Inglewood)",
       "score": null,
       "status": "scheduled",
@@ -968,6 +1041,7 @@
       "home": "1E",
       "away": "3A/B/C/D/F",
       "group": null,
+      "round": "Round of 32",
       "ground": "Boston (Foxborough)",
       "score": null,
       "status": "scheduled",
@@ -980,6 +1054,7 @@
       "home": "1F",
       "away": "2C",
       "group": null,
+      "round": "Round of 32",
       "ground": "Monterrey (Guadalupe)",
       "score": null,
       "status": "scheduled",
@@ -992,6 +1067,7 @@
       "home": "1C",
       "away": "2F",
       "group": null,
+      "round": "Round of 32",
       "ground": "Houston",
       "score": null,
       "status": "scheduled",
@@ -1004,6 +1080,7 @@
       "home": "1I",
       "away": "3C/D/F/G/H",
       "group": null,
+      "round": "Round of 32",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
       "status": "scheduled",
@@ -1016,6 +1093,7 @@
       "home": "2E",
       "away": "2I",
       "group": null,
+      "round": "Round of 32",
       "ground": "Dallas (Arlington)",
       "score": null,
       "status": "scheduled",
@@ -1028,6 +1106,7 @@
       "home": "1A",
       "away": "3C/E/F/H/I",
       "group": null,
+      "round": "Round of 32",
       "ground": "Mexico City",
       "score": null,
       "status": "scheduled",
@@ -1040,6 +1119,7 @@
       "home": "1L",
       "away": "3E/H/I/J/K",
       "group": null,
+      "round": "Round of 32",
       "ground": "Atlanta",
       "score": null,
       "status": "scheduled",
@@ -1052,6 +1132,7 @@
       "home": "1D",
       "away": "3B/E/F/I/J",
       "group": null,
+      "round": "Round of 32",
       "ground": "San Francisco Bay Area (Santa Clara)",
       "score": null,
       "status": "scheduled",
@@ -1064,6 +1145,7 @@
       "home": "1G",
       "away": "3A/E/H/I/J",
       "group": null,
+      "round": "Round of 32",
       "ground": "Seattle",
       "score": null,
       "status": "scheduled",
@@ -1076,6 +1158,7 @@
       "home": "2K",
       "away": "2L",
       "group": null,
+      "round": "Round of 32",
       "ground": "Toronto",
       "score": null,
       "status": "scheduled",
@@ -1088,6 +1171,7 @@
       "home": "1H",
       "away": "2J",
       "group": null,
+      "round": "Round of 32",
       "ground": "Los Angeles (Inglewood)",
       "score": null,
       "status": "scheduled",
@@ -1100,6 +1184,7 @@
       "home": "1B",
       "away": "3E/F/G/I/J",
       "group": null,
+      "round": "Round of 32",
       "ground": "Vancouver",
       "score": null,
       "status": "scheduled",
@@ -1112,6 +1197,7 @@
       "home": "1J",
       "away": "2H",
       "group": null,
+      "round": "Round of 32",
       "ground": "Miami (Miami Gardens)",
       "score": null,
       "status": "scheduled",
@@ -1124,6 +1210,7 @@
       "home": "1K",
       "away": "3D/E/I/J/L",
       "group": null,
+      "round": "Round of 32",
       "ground": "Kansas City",
       "score": null,
       "status": "scheduled",
@@ -1136,6 +1223,7 @@
       "home": "2D",
       "away": "2G",
       "group": null,
+      "round": "Round of 32",
       "ground": "Dallas (Arlington)",
       "score": null,
       "status": "scheduled",
@@ -1148,6 +1236,7 @@
       "home": "W74",
       "away": "W77",
       "group": null,
+      "round": "Round of 16",
       "ground": "Philadelphia",
       "score": null,
       "status": "scheduled",
@@ -1160,6 +1249,7 @@
       "home": "W73",
       "away": "W75",
       "group": null,
+      "round": "Round of 16",
       "ground": "Houston",
       "score": null,
       "status": "scheduled",
@@ -1172,6 +1262,7 @@
       "home": "W76",
       "away": "W78",
       "group": null,
+      "round": "Round of 16",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
       "status": "scheduled",
@@ -1184,6 +1275,7 @@
       "home": "W79",
       "away": "W80",
       "group": null,
+      "round": "Round of 16",
       "ground": "Mexico City",
       "score": null,
       "status": "scheduled",
@@ -1196,6 +1288,7 @@
       "home": "W83",
       "away": "W84",
       "group": null,
+      "round": "Round of 16",
       "ground": "Dallas (Arlington)",
       "score": null,
       "status": "scheduled",
@@ -1208,6 +1301,7 @@
       "home": "W81",
       "away": "W82",
       "group": null,
+      "round": "Round of 16",
       "ground": "Seattle",
       "score": null,
       "status": "scheduled",
@@ -1220,6 +1314,7 @@
       "home": "W86",
       "away": "W88",
       "group": null,
+      "round": "Round of 16",
       "ground": "Atlanta",
       "score": null,
       "status": "scheduled",
@@ -1232,6 +1327,7 @@
       "home": "W85",
       "away": "W87",
       "group": null,
+      "round": "Round of 16",
       "ground": "Vancouver",
       "score": null,
       "status": "scheduled",
@@ -1244,6 +1340,7 @@
       "home": "W89",
       "away": "W90",
       "group": null,
+      "round": "Quarter-final",
       "ground": "Boston (Foxborough)",
       "score": null,
       "status": "scheduled",
@@ -1256,6 +1353,7 @@
       "home": "W93",
       "away": "W94",
       "group": null,
+      "round": "Quarter-final",
       "ground": "Los Angeles (Inglewood)",
       "score": null,
       "status": "scheduled",
@@ -1268,6 +1366,7 @@
       "home": "W91",
       "away": "W92",
       "group": null,
+      "round": "Quarter-final",
       "ground": "Miami (Miami Gardens)",
       "score": null,
       "status": "scheduled",
@@ -1280,6 +1379,7 @@
       "home": "W95",
       "away": "W96",
       "group": null,
+      "round": "Quarter-final",
       "ground": "Kansas City",
       "score": null,
       "status": "scheduled",
@@ -1292,6 +1392,7 @@
       "home": "W97",
       "away": "W98",
       "group": null,
+      "round": "Semi-final",
       "ground": "Dallas (Arlington)",
       "score": null,
       "status": "scheduled",
@@ -1304,6 +1405,7 @@
       "home": "W99",
       "away": "W100",
       "group": null,
+      "round": "Semi-final",
       "ground": "Atlanta",
       "score": null,
       "status": "scheduled",
@@ -1316,6 +1418,7 @@
       "home": "L101",
       "away": "L102",
       "group": null,
+      "round": "Match for third place",
       "ground": "Miami (Miami Gardens)",
       "score": null,
       "status": "scheduled",
@@ -1328,6 +1431,7 @@
       "home": "W101",
       "away": "W102",
       "group": null,
+      "round": "Final",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
       "status": "scheduled",

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
   <nav class="tabs">
     <button class="tab active" data-view="posiciones">🏆 Posiciones</button>
     <button class="tab" data-view="partidos">📅 Partidos</button>
-    <button class="tab" data-view="jugador">👤 Por Jugador</button>
+    <button class="tab" data-view="grupos">📊 Grupos</button>
+    <button class="tab" data-view="jugador">👤 Jugador</button>
   </nav>
 
   <main id="content" class="content">
@@ -42,8 +43,8 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=9"></script>
-  <script src="assets/js/data.js?v=9"></script>
-  <script src="assets/js/app.js?v=9"></script>
+  <script src="assets/js/scoring.js?v=10"></script>
+  <script src="assets/js/data.js?v=10"></script>
+  <script src="assets/js/app.js?v=10"></script>
 </body>
 </html>

--- a/scripts/fetch_results.py
+++ b/scripts/fetch_results.py
@@ -104,6 +104,7 @@ def normalize_openfootball(data):
             "home": home,
             "away": away,
             "group": m.get("group"),
+            "round": m.get("round"),
             "ground": m.get("ground"),
             "score": [ft[0], ft[1]] if ft and len(ft) == 2 else None,
             "status": "finished" if ft and len(ft) == 2 else "scheduled",


### PR DESCRIPTION
Nueva pestaña **📊 Grupos** con dos secciones:

1. **Fase de Grupos** — las 12 tablas (PJ/G/E/P/DG/Pts) calculadas de los partidos finalizados (3-1-0). Resalta los 2 primeros (clasifican) y el 3º (posible mejor tercero).
2. **Eliminatorias** — bracket por ronda (Dieciseisavos → Octavos → Cuartos → Semis → Tercer lugar → Final) con marcadores/estado; muestra placeholders (2A, 1C, W73…) hasta que se definan los equipos.

Agrega el campo `round` al `results.json` normalizado (`fetch_results.py` + fallback del navegador). Cache-bust a `?v=10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_