### PR TITLE
Compress outsider odds + alphabetical Jugador list

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -191,9 +191,10 @@
 
   function renderJugador() {
     const wrap = el("div");
-    state.player = state.player || state.bets.players[0];
+    const players = state.bets.players.slice().sort((a, b) => a.localeCompare(b, "es"));
+    state.player = state.player || players[0];
     const sel = el("select", "pselect",
-      state.bets.players.map((p) => `<option ${p === state.player ? "selected" : ""}>${p}</option>`).join(""));
+      players.map((p) => `<option ${p === state.player ? "selected" : ""}>${p}</option>`).join(""));
     sel.addEventListener("change", (e) => { state.player = e.target.value; render(); });
     wrap.appendChild(sel);
 

--- a/assets/js/odds.js
+++ b/assets/js/odds.js
@@ -53,9 +53,12 @@
       if (fh && fh.pj) rh += 0.15 * Math.log((fh.atk || 1) / (fh.def || 1));
       if (fa && fa.pj) ra += 0.15 * Math.log((fa.atk || 1) / (fa.def || 1));
     }
-    const sup = (rh - ra) + HOME_ADV;
+    // Compress supremacy a touch and floor the underdog's λ so extreme outsiders
+    // aren't priced too long (Poisson otherwise under-rates upsets).
+    const COMPRESS = 0.95, FLOOR = 0.22;
+    const sup = ((rh - ra) + HOME_ADV) * COMPRESS;
     const T = Math.max(2.2, Math.min(3.6, 2.5 + 0.12 * Math.abs(sup)));
-    return { lh: Math.max(0.12, (T + sup) / 2), la: Math.max(0.12, (T - sup) / 2) };
+    return { lh: Math.max(FLOOR, (T + sup) / 2), la: Math.max(FLOOR, (T - sup) / 2) };
   }
 
   // Markets from λ. For live games pass remFrac (remaining time fraction) and the

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=12"></script>
-  <script src="assets/js/odds.js?v=12"></script>
-  <script src="assets/js/data.js?v=12"></script>
-  <script src="assets/js/app.js?v=12"></script>
+  <script src="assets/js/scoring.js?v=13"></script>
+  <script src="assets/js/odds.js?v=13"></script>
+  <script src="assets/js/data.js?v=13"></script>
+  <script src="assets/js/app.js?v=13"></script>
 </body>
 </html>


### PR DESCRIPTION
1. **Comprime outsiders:** escala la supremacía ×0.95 y pone piso a la λ del no-favorito (0.22), para que los outsiders extremos no queden con momio demasiado largo. Irak ~27 (libro 28), Arabia ~20 (21); favoritos/medios se mantienen cerca.
2. **Jugador A→Z:** el selector de jugador ahora está ordenado alfabéticamente (Christian, David, Gerardo…).

Cache-bust `?v=13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_