### PR TITLE
Knockout as a horizontal bracket diagram

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -176,16 +176,33 @@ body > * { position: relative; z-index: 1; }
 .phcode { color: var(--muted); font-weight: 700; font-size: 0.8rem; background: var(--bg2); border: 1px dashed var(--line); border-radius: 6px; padding: 1px 6px; }
 
 .bracket { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; align-items: start; }
-.round { background: rgba(0,0,0,0.15); border: 1px solid var(--line); border-radius: var(--radius); padding: 8px 10px 10px; }
-.rhdr { margin: 2px 0 8px; font-size: 0.9rem; color: var(--gold); text-align: center; }
-.tie { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 8px 10px; margin-bottom: 8px; }
-.tiehead { display: flex; align-items: center; gap: 6px; font-size: 0.7rem; color: var(--muted); margin-bottom: 6px; }
-.tiehead .tdate { margin-right: auto; text-transform: capitalize; }
-.tierow { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 6px; }
-.tierow .team:last-child { justify-content: flex-end; }
-.tscore { font-weight: 800; min-width: 42px; text-align: center; color: var(--muted); }
-.tscore.finished, .tscore.live { color: var(--txt); }
-.tscore.live { color: var(--live); }
+
+/* Horizontal knockout bracket (rounds → Campeón) */
+.bracket2 { display: flex; overflow-x: auto; -webkit-overflow-scrolling: touch; padding: 4px 0 12px; scrollbar-width: thin; }
+.bracket2::-webkit-scrollbar { height: 8px; }
+.bracket2::-webkit-scrollbar-thumb { background: var(--line); border-radius: 8px; }
+.bround { flex: 0 0 auto; min-width: 150px; padding: 0 10px; display: flex; flex-direction: column; }
+.bround.champ-col { min-width: 130px; justify-content: center; }
+.brh { font-size: 0.7rem; color: var(--gold); text-align: center; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.03em; white-space: nowrap; }
+.bbody { flex: 1; display: flex; flex-direction: column; justify-content: space-around; gap: 10px; }
+.bmatch { background: var(--card); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; position: relative; }
+.bmatch.blive { border-color: var(--live); }
+/* connector stub to the next round */
+.bround:not(.champ-col) .bmatch::after { content: ""; position: absolute; left: 100%; top: 50%; width: 10px; height: 2px; background: var(--line); }
+.bteam { display: flex; align-items: center; gap: 6px; padding: 5px 8px; font-size: 0.8rem; }
+.bteam + .bteam { border-top: 1px solid var(--line); }
+.bteam .flag { font-size: 1.05rem; }
+.bteam .bn { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bteam .bn.ph { color: var(--muted); }
+.bteam .bsc { font-weight: 800; color: var(--muted); min-width: 14px; text-align: right; }
+.bteam.bw { background: rgba(232, 198, 106, 0.12); }
+.bteam.bw .bn { font-weight: 700; color: var(--gold); }
+.bteam.bw .bsc { color: var(--gold); }
+.bchamp { display: flex; align-items: center; justify-content: center; gap: 6px; text-align: center; font-weight: 800; color: var(--gold);
+  background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 10px; padding: 14px 10px; }
+.bchamp .flag { font-size: 1.3rem; }
+.thirdplace { margin-top: 14px; max-width: 320px; }
+.thirdplace .tplabel { display: block; font-size: 0.78rem; color: var(--muted); margin-bottom: 6px; }
 
 /* Cuotas (odds) */
 .oddshelp { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 10px 12px; margin-bottom: 12px; font-size: 0.82rem; color: var(--muted); }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -298,27 +298,61 @@
     });
     wrap.appendChild(grid);
 
-    // --- Knockout bracket (round by round) ---
+    // --- Knockout bracket (horizontal, rounds → Campeón) ---
     wrap.appendChild(el("h2", "sechdr", "Eliminatorias"));
+    wrap.appendChild(el("p", "hint", "Desliza horizontalmente para ver todo el cuadro →"));
     const allKo = Object.values(state.results.matches).filter((m) => m.round && (!m.group || m.group.indexOf("Group") !== 0));
-    const bracket = el("div", "bracket");
-    KO_ROUNDS.forEach(([en, es]) => {
-      const ms = allKo.filter((m) => m.round === en)
-        .sort((a, b) => (Date.parse(a.kickoff_utc) || 0) - (Date.parse(b.kickoff_utc) || 0));
+
+    const brTeam = (name, score, win) => {
+      const t = state.teams[name];
+      const inner = t ? `<span class="flag">${t.flag}</span><span class="bn">${t.es}</span>`
+                      : `<span class="bn ph">${name || "?"}</span>`;
+      return `<div class="bteam ${win ? "bw" : ""}">${inner}<span class="bsc">${score != null ? score : ""}</span></div>`;
+    };
+    const bnode = (m) => {
+      const fin = m.status === "finished" && m.score;
+      const w0 = fin && m.score[0] > m.score[1], w1 = fin && m.score[1] > m.score[0];
+      const n = el("div", "bmatch" + (m.status === "live" ? " blive" : ""));
+      n.innerHTML = brTeam(m.home, m.score ? m.score[0] : null, w0) + brTeam(m.away, m.score ? m.score[1] : null, w1);
+      return n;
+    };
+
+    const order = ["Round of 32", "Round of 16", "Quarter-final", "Semi-final", "Final"];
+    const bracket = el("div", "bracket2");
+    order.forEach((rn) => {
+      const ms = allKo.filter((m) => m.round === rn); // keep feed (bracket) order
       if (!ms.length) return;
-      const col = el("div", "round");
-      col.appendChild(el("h3", "rhdr", es));
-      ms.forEach((m) => {
-        const score = m.score ? `${m.score[0]}–${m.score[1]}` : "vs";
-        const tie = el("div", "tie");
-        tie.innerHTML = `
-          <div class="tiehead"><span class="tdate">${fmtDay(m.date)} · ${fmtKickoffTime(m)}</span>${statusBadge(m)}</div>
-          <div class="tierow">${koTeamHTML(m.home)}<span class="tscore ${m.status}">${score}</span>${koTeamHTML(m.away)}</div>`;
-        col.appendChild(tie);
-      });
+      const col = el("div", "bround");
+      col.innerHTML = `<div class="brh">${roundES(rn)}</div>`;
+      const body = el("div", "bbody");
+      ms.forEach((m) => body.appendChild(bnode(m)));
+      col.appendChild(body);
       bracket.appendChild(col);
     });
+    // Champion column
+    const final = allKo.find((m) => m.round === "Final");
+    let champ = null;
+    if (final && final.status === "finished" && final.score && final.score[0] !== final.score[1])
+      champ = final.score[0] > final.score[1] ? final.home : final.away;
+    const cc = el("div", "bround champ-col");
+    cc.innerHTML = `<div class="brh">Campeón</div>`;
+    const cb = el("div", "bbody");
+    const champHtml = champ
+      ? (state.teams[champ] ? `<span class="flag">${state.teams[champ].flag}</span> ${state.teams[champ].es}` : champ)
+      : "🏆 ¿?";
+    cb.innerHTML = `<div class="bchamp">${champHtml}</div>`;
+    cc.appendChild(cb);
+    bracket.appendChild(cc);
     wrap.appendChild(bracket);
+
+    // 3rd place
+    const tp = allKo.find((m) => m.round === "Match for third place");
+    if (tp) {
+      const box = el("div", "thirdplace");
+      box.innerHTML = `<span class="tplabel">🥉 Tercer lugar</span>`;
+      box.appendChild(bnode(tp));
+      wrap.appendChild(box);
+    }
     return wrap;
   }
 

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=13"></script>
-  <script src="assets/js/odds.js?v=13"></script>
-  <script src="assets/js/data.js?v=13"></script>
-  <script src="assets/js/app.js?v=13"></script>
+  <script src="assets/js/scoring.js?v=14"></script>
+  <script src="assets/js/odds.js?v=14"></script>
+  <script src="assets/js/data.js?v=14"></script>
+  <script src="assets/js/app.js?v=14"></script>
 </body>
 </html>


### PR DESCRIPTION
Rediseña **Eliminatorias** como un verdadero **diagrama de bracket**: rondas en columnas (Dieciseisavos → Octavos → Cuartos → Semis → Final) que fluyen de izquierda a derecha hacia el nodo **Campeón**, con banderas, resaltado del ganador, líneas conectoras y un recuadro de **3er lugar**. Se desliza horizontalmente en el celular. Muestra placeholders (2A, W74…) hasta que se definan los equipos. Cache-bust `?v=14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_