### PR TITLE
Bracket: flags + team names (resolve slot codes)

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -194,6 +194,7 @@ body > * { position: relative; z-index: 1; }
 .bteam .flag { font-size: 1.05rem; }
 .bteam .bn { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .bteam .bn.ph { color: var(--muted); }
+.bteam .bn.proj { font-style: italic; }
 .bteam .bsc { font-weight: 800; color: var(--muted); min-width: 14px; text-align: right; }
 .bteam.bw { background: rgba(232, 198, 106, 0.12); }
 .bteam.bw .bn { font-weight: 700; color: var(--gold); }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -303,10 +303,32 @@
     wrap.appendChild(el("p", "hint", "Desliza horizontalmente para ver todo el cuadro →"));
     const allKo = Object.values(state.results.matches).filter((m) => m.round && (!m.group || m.group.indexOf("Group") !== 0));
 
-    const brTeam = (name, score, win) => {
-      const t = state.teams[name];
-      const inner = t ? `<span class="flag">${t.flag}</span><span class="bn">${t.es}</span>`
-                      : `<span class="bn ph">${name || "?"}</span>`;
+    // Resolve bracket slot codes to real teams (projected from current standings):
+    //  1X/2X -> winner/runner-up of group X; 3-slots & W/L codes stay as labels
+    //  until decided (openfootball fills real team names into the feed by then).
+    const gt = tables; // group tables computed above (Group X -> sorted rows)
+    const resolveSlot = (code) => {
+      if (state.teams[code]) return { name: code, proj: false };
+      const m = /^([12])([A-L])$/.exec(code || "");
+      if (m) {
+        const arr = gt["Group " + m[2]];
+        if (arr && arr[+m[1] - 1]) return { name: arr[+m[1] - 1].team, proj: true };
+      }
+      return { name: null, code: code };
+    };
+    const slotLabel = (code) => /^3/.test(code || "")
+      ? "3º " + code.slice(1).replace(/\//g, "·")
+      : "Por definir";
+
+    const brTeam = (code, score, win) => {
+      const r = resolveSlot(code);
+      let inner;
+      if (r.name && state.teams[r.name]) {
+        const t = state.teams[r.name];
+        inner = `<span class="flag">${t.flag}</span><span class="bn ${r.proj ? "proj" : ""}">${t.es}</span>`;
+      } else {
+        inner = `<span class="bn ph">${slotLabel(code)}</span>`;
+      }
       return `<div class="bteam ${win ? "bw" : ""}">${inner}<span class="bsc">${score != null ? score : ""}</span></div>`;
     };
     const bnode = (m) => {

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=14"></script>
-  <script src="assets/js/odds.js?v=14"></script>
-  <script src="assets/js/data.js?v=14"></script>
-  <script src="assets/js/app.js?v=14"></script>
+  <script src="assets/js/scoring.js?v=15"></script>
+  <script src="assets/js/odds.js?v=15"></script>
+  <script src="assets/js/data.js?v=15"></script>
+  <script src="assets/js/app.js?v=15"></script>
 </body>
 </html>


### PR DESCRIPTION
El bracket ahora resuelve los códigos a equipos reales: los slots **1X/2X** muestran al líder/sublíder actual de ese grupo con **bandera + nombre** (proyectado, en itálica) en vez de "2A/2B". Los slots de mejor tercero y de ganador (W74…) muestran "3º A·B·C·…" / "Por definir" hasta que se definan; cuando el feed oficial los llena con equipos reales, se ven normal. Ej. actual: 1A→México, 2B→Suiza, 2C→Marruecos. Cache-bust `?v=15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_