### PR TITLE
Show country names in Juegos tab on mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -247,6 +247,9 @@ body > * { position: relative; z-index: 1; }
 .foot a { color: var(--accent); }
 
 @media (max-width: 480px) {
-  .tname { display: none; }   /* flags-only on narrow screens to keep cards tidy */
-  .jmatch .tname { display: inline; }
+  /* Show country names everywhere on phones; just shrink them a touch in
+     match cards so they fit alongside the score. */
+  .match .tname, .oddscard .tname { font-size: 0.78rem; }
+  .mscore .side { min-width: 0; }
+  .mscore .tname { white-space: normal; overflow-wrap: anywhere; }
 }

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=18"></script>
-  <script src="assets/js/odds.js?v=18"></script>
-  <script src="assets/js/data.js?v=18"></script>
-  <script src="assets/js/app.js?v=18"></script>
+  <script src="assets/js/scoring.js?v=19"></script>
+  <script src="assets/js/odds.js?v=19"></script>
+  <script src="assets/js/data.js?v=19"></script>
+  <script src="assets/js/app.js?v=19"></script>
 </body>
 </html>


### PR DESCRIPTION
En celular las tarjetas de **Juegos** mostraban solo banderas (una regla ocultaba los nombres). Ahora se muestran los **nombres de los países** también en móvil, un poco más chicos y con salto de línea para que quepan junto al marcador. Aplica igual a las tarjetas de Odds. Cache-bust `?v=19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_