### PR TITLE
Merge OddsPapi Worker fix (debug + UA) to main

### DIFF
--- a/worker/oddspapi-proxy.js
+++ b/worker/oddspapi-proxy.js
@@ -2,24 +2,22 @@
  * Los Reyes Quiniela — OddsPapi proxy (Cloudflare Worker).
  *
  * Adds CORS + hides the API key + caches responses for several hours so the free
- * tier (≈250–1000 req/month) isn't exhausted. The browser/site calls THIS worker;
- * the worker injects the key and forwards to OddsPapi.
+ * tier (≈250–1000 req/month) isn't exhausted. The site calls THIS worker; it
+ * injects the key and forwards to OddsPapi.
  *
- * SECURITY: the API key is read from an environment variable, never hardcoded.
- *   In the Cloudflare dashboard: your Worker → Settings → Variables and Secrets →
- *   add a *Secret* named  ODDSPAPI_KEY  with your key as the value → Deploy.
+ * SECURITY: the API key is read from a Worker *Secret* named ODDSPAPI_KEY
+ * (Settings → Variables and Secrets → add Secret). Never hardcode it.
  *
- * USAGE (the site will call it like this):
- *   GET  https://<worker>.workers.dev/?path=/sports
- *   GET  https://<worker>.workers.dev/?path=/odds&sport=<key>&markets=h2h,totals&...
- * The `path` param selects the OddsPapi v4 endpoint; all other query params are
- * forwarded as-is; `apiKey` is added server-side. Responses are edge-cached.
- *
- * Deploy: dash.cloudflare.com → Workers & Pages → Create Worker → paste this →
- * add the ODDSPAPI_KEY secret → Deploy. Copy the URL and send it to me.
+ * USAGE:
+ *   GET /?path=/sports
+ *   GET /?path=/odds&sportId=10&...        (path = OddsPapi v4 endpoint)
+ *   GET /?path=/sports&debug=1             (debug: shows upstream status + sample)
+ * `apiKey` is added server-side; all other params are forwarded. Edge-cached ~6h.
  */
 const API_BASE = "https://api.oddspapi.io/v4";
 const CACHE_SECONDS = 6 * 60 * 60; // 6 hours
+// A browser-like UA — some APIs 403 non-browser/unknown user agents.
+const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -30,42 +28,53 @@ const CORS = {
 export default {
   async fetch(request, env) {
     if (request.method === "OPTIONS") return new Response(null, { headers: CORS });
-    if (request.method !== "GET") {
-      return json({ error: "method not allowed" }, 405);
-    }
-    if (!env || !env.ODDSPAPI_KEY) {
-      return json({ error: "ODDSPAPI_KEY secret not set on this Worker" }, 500);
-    }
+    if (request.method !== "GET") return json({ error: "method not allowed" }, 405);
+
+    const key = (env && env.ODDSPAPI_KEY ? String(env.ODDSPAPI_KEY) : "").trim();
+    if (!key) return json({ error: "ODDSPAPI_KEY secret not set on this Worker" }, 500);
 
     const inUrl = new URL(request.url);
-    // Endpoint path (default to /sports so a bare call verifies the key works).
     let path = inUrl.searchParams.get("path") || "/sports";
     if (!path.startsWith("/")) path = "/" + path;
+    const debug = inUrl.searchParams.get("debug");
 
-    // Build the upstream URL: forward all params except `path`, add apiKey.
     const upstream = new URL(API_BASE + path);
     for (const [k, v] of inUrl.searchParams) {
-      if (k !== "path" && k !== "apiKey") upstream.searchParams.set(k, v);
+      if (k !== "path" && k !== "apiKey" && k !== "debug") upstream.searchParams.set(k, v);
     }
-    upstream.searchParams.set("apiKey", env.ODDSPAPI_KEY);
+    upstream.searchParams.set("apiKey", key);
 
-    // Edge cache keyed WITHOUT the API key (so the key never lands in cache keys).
+    // Edge cache keyed WITHOUT the key.
     const cacheKey = new Request(new URL(inUrl.pathname + inUrl.search, inUrl.origin).toString());
     const cache = caches.default;
-    let hit = await cache.match(cacheKey);
-    if (hit) return withCors(hit);
+    if (!debug) {
+      const hit = await cache.match(cacheKey);
+      if (hit) return withCors(hit);
+    }
 
-    let upstreamRes;
+    let upstreamRes, body;
     try {
       upstreamRes = await fetch(upstream.toString(), {
-        headers: { Accept: "application/json", "User-Agent": "los-reyes-quiniela/1.0" },
-        cf: { cacheTtl: CACHE_SECONDS, cacheEverything: true },
+        headers: {
+          "Accept": "application/json",
+          "User-Agent": UA,
+          "Referer": "https://oddspapi.io/",
+        },
       });
+      body = await upstreamRes.text();
     } catch (e) {
       return json({ error: "upstream fetch failed: " + String(e) }, 502);
     }
 
-    const body = await upstreamRes.text();
+    if (debug) {
+      return json({
+        upstream: upstream.toString().replace(key, "***"),
+        status: upstreamRes.status,
+        keyLength: key.length,
+        sample: body.slice(0, 400),
+      }, 200);
+    }
+
     const res = new Response(body, {
       status: upstreamRes.status,
       headers: {
@@ -74,7 +83,6 @@ export default {
         "Cache-Control": `public, max-age=${CACHE_SECONDS}`,
       },
     });
-    // Only cache successful responses.
     if (upstreamRes.ok) await cache.put(cacheKey, res.clone());
     return res;
   },


### PR DESCRIPTION
Mergea a `main` el fix del Worker de OddsPapi (browser User-Agent + Referer, `.trim()` a la key, sin el cf cacheEverything, y modo `?debug=1`). Antes solo estaba en la rama, por eso el archivo en main seguía siendo el viejo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_