### PR TITLE
Show kickoff time (ET) on knockout bracket

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -199,7 +199,7 @@ body > * { position: relative; z-index: 1; }
 .bbody { flex: 1; display: flex; flex-direction: column; justify-content: space-around; gap: 10px; }
 .bmatch { background: var(--card); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; position: relative; }
 .bmatch.blive { border-color: var(--live); }
-.bmatch .bdate { font-size: 0.6rem; font-weight: 700; letter-spacing: 0.02em; text-align: center;
+.bmatch .bdate { font-size: 0.6rem; font-weight: 700; letter-spacing: 0.02em; text-align: center; white-space: nowrap;
   color: var(--muted); padding: 2px 6px; background: var(--bg2); border-bottom: 1px solid var(--line); text-transform: uppercase; }
 .bmatch .bdate:empty { display: none; }
 /* connector stub to the next round */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -163,6 +163,22 @@
     return new Date(ko).toLocaleTimeString("es-MX", { hour: "2-digit", minute: "2-digit" });
   }
 
+  // Compact "28 jun · 3:00 PM ET" for the knockout bracket nodes (Eastern time).
+  function bracketWhen(m) {
+    const ko = m.kickoff_utc ? (typeof m.kickoff_utc === "number" ? m.kickoff_utc : Date.parse(m.kickoff_utc)) : 0;
+    if (ko) {
+      const d = new Date(ko);
+      const dayStr = d.toLocaleDateString("es-MX", { timeZone: "America/New_York", day: "numeric", month: "short" });
+      const time = d.toLocaleTimeString("en-US", { timeZone: "America/New_York", hour: "numeric", minute: "2-digit", hour12: true });
+      return `${dayStr} · ${time} ET`;
+    }
+    if (m.date) {
+      const d = new Date(m.date + "T12:00:00");
+      return `${d.getDate()} ${MONTHS[d.getMonth()]}`;
+    }
+    return "";
+  }
+
   function statusBadge(m) {
     if (m.status === "live") {
       const raw = m.minute != null ? String(m.minute) : "";
@@ -452,8 +468,7 @@
       const fin = m.status === "finished" && m.score;
       const w0 = fin && m.score[0] > m.score[1], w1 = fin && m.score[1] > m.score[0];
       const n = el("div", "bmatch" + (m.status === "live" ? " blive" : ""));
-      const d = m.date ? new Date(m.date + "T12:00:00") : null;
-      const ds = d ? `${d.getDate()} ${MONTHS[d.getMonth()]}` : "";
+      const ds = bracketWhen(m);
       n.innerHTML = `<div class="bdate">${ds}</div>` +
         brTeam(m.home, m.score ? m.score[0] : null, w0) + brTeam(m.away, m.score ? m.score[1] : null, w1);
       return n;

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=23"></script>
-  <script src="assets/js/odds.js?v=23"></script>
-  <script src="assets/js/data.js?v=23"></script>
-  <script src="assets/js/app.js?v=23"></script>
+  <script src="assets/js/scoring.js?v=24"></script>
+  <script src="assets/js/odds.js?v=24"></script>
+  <script src="assets/js/data.js?v=24"></script>
+  <script src="assets/js/app.js?v=24"></script>
 </body>
 </html>


### PR DESCRIPTION
Builds on the bracket-date change: each knockout bracket node now shows the date **and** kickoff time in Eastern time, e.g. `28 jun · 3:00 PM ET`.

- `app.js`: new `bracketWhen(m)` helper formats `kickoff_utc` as day + month + time in `America/New_York`; falls back to date-only when no kickoff is set.
- `styles.css`: `.bdate` stays on one line (`white-space: nowrap`).
- `index.html`: cache-bust `v23` → `v24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_