### PR TITLE
Condense knockout bracket (flags + date/time, no names)

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -193,8 +193,8 @@ body > * { position: relative; z-index: 1; }
 .bracket2 { display: flex; overflow-x: auto; -webkit-overflow-scrolling: touch; padding: 4px 0 12px; scrollbar-width: thin; }
 .bracket2::-webkit-scrollbar { height: 8px; }
 .bracket2::-webkit-scrollbar-thumb { background: var(--line); border-radius: 8px; }
-.bround { flex: 0 0 auto; min-width: 150px; padding: 0 10px; display: flex; flex-direction: column; }
-.bround.champ-col { min-width: 130px; justify-content: center; }
+.bround { flex: 0 0 auto; min-width: 92px; padding: 0 8px; display: flex; flex-direction: column; }
+.bround.champ-col { min-width: 120px; justify-content: center; }
 .brh { font-size: 0.7rem; color: var(--gold); text-align: center; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.03em; white-space: nowrap; }
 .bbody { flex: 1; display: flex; flex-direction: column; justify-content: space-around; gap: 10px; }
 .bmatch { background: var(--card); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; position: relative; }
@@ -204,15 +204,14 @@ body > * { position: relative; z-index: 1; }
 .bmatch .bdate:empty { display: none; }
 /* connector stub to the next round */
 .bround:not(.champ-col) .bmatch::after { content: ""; position: absolute; left: 100%; top: 50%; width: 10px; height: 2px; background: var(--line); }
-.bteam { display: flex; align-items: center; gap: 6px; padding: 5px 8px; font-size: 0.8rem; }
+.bteam { display: flex; align-items: center; gap: 6px; padding: 6px 8px; font-size: 0.8rem; }
 .bteam + .bteam { border-top: 1px solid var(--line); }
-.bteam .flag { font-size: 1.05rem; }
+.bteam .flag { font-size: 1.45rem; line-height: 1; }
+.bteam .flag.proj { opacity: 0.5; }
 .bteam .bn { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.bteam .bn.ph { color: var(--muted); }
-.bteam .bn.proj { font-style: italic; }
-.bteam .bsc { font-weight: 800; color: var(--muted); min-width: 14px; text-align: right; }
+.bteam .bn.ph { font-size: 0.72rem; color: var(--muted); }
+.bteam .bsc { font-weight: 800; color: var(--muted); min-width: 14px; text-align: right; margin-left: auto; }
 .bteam.bw { background: rgba(232, 198, 106, 0.12); }
-.bteam.bw .bn { font-weight: 700; color: var(--gold); }
 .bteam.bw .bsc { color: var(--gold); }
 .bchamp { display: flex; align-items: center; justify-content: center; gap: 6px; text-align: center; font-weight: 800; color: var(--gold);
   background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 10px; padding: 14px 10px; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -449,18 +449,22 @@
       }
       return { name: null, code: code };
     };
-    const slotLabel = (code) => /^3/.test(code || "")
-      ? "3º " + code.slice(1).replace(/\//g, "·")
-      : "Por definir";
+    // Condensed bracket: flags only (no country names). Short code when the slot
+    // isn't decided yet (e.g. "3º", "1A"); the full name stays on hover/long-press.
+    const slotShort = (code) => {
+      if (/^3/.test(code || "")) return "3º";
+      const m = /^([12])([A-L])$/.exec(code || "");
+      return m ? code : "—";
+    };
 
     const brTeam = (code, score, win) => {
       const r = resolveSlot(code);
       let inner;
       if (r.name && state.teams[r.name]) {
         const t = state.teams[r.name];
-        inner = `<span class="flag">${t.flag}</span><span class="bn ${r.proj ? "proj" : ""}">${t.es}</span>`;
+        inner = `<span class="flag ${r.proj ? "proj" : ""}" title="${t.es}">${t.flag}</span>`;
       } else {
-        inner = `<span class="bn ph">${slotLabel(code)}</span>`;
+        inner = `<span class="bn ph">${slotShort(code)}</span>`;
       }
       return `<div class="bteam ${win ? "bw" : ""}">${inner}<span class="bsc">${score != null ? score : ""}</span></div>`;
     };

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=24"></script>
-  <script src="assets/js/odds.js?v=24"></script>
-  <script src="assets/js/data.js?v=24"></script>
-  <script src="assets/js/app.js?v=24"></script>
+  <script src="assets/js/scoring.js?v=25"></script>
+  <script src="assets/js/odds.js?v=25"></script>
+  <script src="assets/js/data.js?v=25"></script>
+  <script src="assets/js/app.js?v=25"></script>
 </body>
 </html>


### PR DESCRIPTION
Makes the **Grupos** knockout bracket a tighter, DAZN-style view.

- Each match node now shows only **flags + score**, with the **date · time ET** header on top — country names removed.
- Undecided slots show a short code (`3º`, `1A`) instead of "Por definir"; full country name is kept as a `title` tooltip on hover/long-press.
- Narrower columns (min-width 150→92px), larger flags for legibility.
- `index.html`: cache-bust `v24` → `v25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_