### PR TITLE
Compress bracket columns + short round headers

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -194,37 +194,39 @@ body > * { position: relative; z-index: 1; }
 .bracket2.mirror { min-width: max-content; }
 .bracket2::-webkit-scrollbar { height: 8px; }
 .bracket2::-webkit-scrollbar-thumb { background: var(--line); border-radius: 8px; }
-.bround { flex: 0 0 auto; min-width: 86px; padding: 0 7px; display: flex; flex-direction: column; }
-.brh { font-size: 0.66rem; color: var(--gold); text-align: center; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.03em; white-space: nowrap; }
-.bbody { flex: 1; display: flex; flex-direction: column; justify-content: space-around; gap: 8px; }
-.bmatch { background: var(--card); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; position: relative; }
+.bround { flex: 0 0 auto; min-width: 0; padding: 0 2px; display: flex; flex-direction: column; }
+.brh { font-size: 0.62rem; color: var(--gold); text-align: center; margin-bottom: 5px; text-transform: uppercase; letter-spacing: 0.02em; white-space: nowrap; }
+.bbody { flex: 1; display: flex; flex-direction: column; justify-content: space-around; gap: 5px; }
+.bmatch { background: var(--card); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; position: relative; }
 .bmatch.blive { border-color: var(--live); }
-.bmatch .bdate { font-size: 0.58rem; font-weight: 700; letter-spacing: 0.02em; text-align: center; white-space: nowrap;
-  color: var(--muted); padding: 2px 6px; background: var(--bg2); border-bottom: 1px solid var(--line); text-transform: uppercase; }
+/* date + time stacked on two tiny lines to keep columns narrow */
+.bmatch .bdate { display: flex; flex-direction: column; align-items: center; line-height: 1.1; font-size: 0.5rem; font-weight: 700;
+  letter-spacing: 0.01em; white-space: nowrap; color: var(--muted); padding: 1px 3px; background: var(--bg2); border-bottom: 1px solid var(--line); text-transform: uppercase; }
 .bmatch .bdate:empty { display: none; }
+.bmatch .bdate .bd-t { color: var(--txt); }
 /* connector stubs point inward (toward the center column) */
-.bround.left .bmatch::after { content: ""; position: absolute; left: 100%; top: 50%; width: 9px; height: 2px; background: var(--line); }
-.bround.right .bmatch::after { content: ""; position: absolute; right: 100%; top: 50%; width: 9px; height: 2px; background: var(--line); }
-.bteam { display: flex; align-items: center; gap: 6px; padding: 6px 8px; font-size: 0.8rem; }
+.bround.left .bmatch::after { content: ""; position: absolute; left: 100%; top: 50%; width: 5px; height: 2px; background: var(--line); }
+.bround.right .bmatch::after { content: ""; position: absolute; right: 100%; top: 50%; width: 5px; height: 2px; background: var(--line); }
+.bteam { display: flex; align-items: center; gap: 3px; padding: 3px 4px; font-size: 0.75rem; }
 .bteam + .bteam { border-top: 1px solid var(--line); }
-.bteam .flag { font-size: 1.4rem; line-height: 1; }
+.bteam .flag { font-size: 1.2rem; line-height: 1; }
 .bteam .flag.proj { opacity: 0.5; }
 .bteam .bn { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.bteam .bn.ph { font-size: 0.72rem; color: var(--muted); }
-.bteam .bsc { font-weight: 800; color: var(--muted); min-width: 14px; text-align: right; margin-left: auto; }
+.bteam .bn.ph { font-size: 0.68rem; color: var(--muted); }
+.bteam .bsc { font-weight: 800; color: var(--muted); min-width: 11px; text-align: right; margin-left: auto; }
 .bteam.bw { background: rgba(232, 198, 106, 0.12); }
 .bteam.bw .bsc { color: var(--gold); }
 /* mirror the right half so flags face inward like the poster */
 .bround.right .bteam { flex-direction: row-reverse; }
 .bround.right .bteam .bsc { margin-left: 0; margin-right: auto; text-align: left; }
 /* center column: trophy + Final + champion + 3rd place */
-.center-col { min-width: 132px; justify-content: center; align-items: stretch; }
-.center-col .btrophy { font-size: 2rem; text-align: center; line-height: 1; margin-bottom: 2px; }
+.center-col { min-width: 0; justify-content: center; align-items: stretch; padding: 0 4px; }
+.center-col .btrophy { font-size: 1.7rem; text-align: center; line-height: 1; margin-bottom: 2px; }
 .center-col .bmatch { border-color: var(--gold-deep); }
-.bchamp { display: flex; align-items: center; justify-content: center; gap: 6px; text-align: center; font-weight: 800; color: var(--gold); margin-top: 8px;
-  background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 10px; padding: 12px 10px; }
-.bchamp .flag { font-size: 1.3rem; }
-.center-col .b3rdlabel { font-size: 0.7rem; color: var(--muted); text-align: center; margin: 14px 0 6px; text-transform: uppercase; letter-spacing: 0.02em; }
+.bchamp { display: flex; align-items: center; justify-content: center; gap: 5px; text-align: center; font-weight: 800; font-size: 0.78rem; color: var(--gold); margin-top: 6px;
+  background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 8px; padding: 9px 6px; }
+.bchamp .flag { font-size: 1.2rem; }
+.center-col .b3rdlabel { font-size: 0.62rem; color: var(--muted); text-align: center; margin: 10px 0 5px; text-transform: uppercase; letter-spacing: 0.02em; }
 
 /* Title Pie */
 .titlepie { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 12px; margin-bottom: 12px; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -170,11 +170,11 @@
       const d = new Date(ko);
       const dayStr = d.toLocaleDateString("es-MX", { timeZone: "America/New_York", day: "numeric", month: "short" });
       const time = d.toLocaleTimeString("en-US", { timeZone: "America/New_York", hour: "numeric", minute: "2-digit", hour12: true });
-      return `${dayStr} · ${time} ET`;
+      return `<span class="bd-d">${dayStr}</span><span class="bd-t">${time}</span>`;
     }
     if (m.date) {
       const d = new Date(m.date + "T12:00:00");
-      return `${d.getDate()} ${MONTHS[d.getMonth()]}`;
+      return `<span class="bd-d">${d.getDate()} ${MONTHS[d.getMonth()]}</span>`;
     }
     return "";
   }
@@ -410,7 +410,7 @@
     97: [89, 90], 98: [93, 94], 99: [91, 92], 100: [95, 96],
     101: [97, 98], 102: [99, 100], 104: [101, 102],
   };
-  const KO_COL_ES = ["Dieciseisavos", "Octavos", "Cuartos", "Semifinal"]; // R32→SF
+  const KO_COL_ES = ["16", "8", "4", "SF"]; // R32→SF column headers (compact)
 
   function renderGrupos() {
     const wrap = el("div");
@@ -451,7 +451,7 @@
   function renderEliminatorias() {
     const wrap = el("div");
     wrap.appendChild(el("h2", "sechdr", "Eliminatorias"));
-    wrap.appendChild(el("p", "hint", "Desliza horizontalmente para ver todo el cuadro → · Marcadores en vivo conforme se juegan."));
+    wrap.appendChild(el("p", "hint", "Marcadores en vivo conforme se juegan · Horarios en hora del Este (ET) · 16 = Dieciseisavos · 8 = Octavos · 4 = Cuartos · SF = Semifinal · F = Final."));
     appendKnockout(wrap, computeGroupTables(), { header: false });
     return wrap;
   }
@@ -542,7 +542,7 @@
     if (final && final.status === "finished" && final.score && final.score[0] !== final.score[1])
       champ = final.score[0] > final.score[1] ? final.home : final.away;
     const center = el("div", "bround center-col");
-    center.innerHTML = `<div class="btrophy">🏆</div><div class="brh">Final</div>`;
+    center.innerHTML = `<div class="btrophy">🏆</div><div class="brh">F</div>`;
     if (final) center.appendChild(bnode(final));
     const champBox = el("div", "bchamp");
     champBox.innerHTML = champ

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-28T19:39:38.547070+00:00",
+  "generated_at": "2026-06-28T19:52:52.388538+00:00",
   "matches": {
     "2026-06-11|Mexico|South Africa": {
       "num": null,

--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=27"></script>
-  <script src="assets/js/odds.js?v=27"></script>
-  <script src="assets/js/data.js?v=27"></script>
-  <script src="assets/js/app.js?v=27"></script>
+  <script src="assets/js/scoring.js?v=28"></script>
+  <script src="assets/js/odds.js?v=28"></script>
+  <script src="assets/js/data.js?v=28"></script>
+  <script src="assets/js/app.js?v=28"></script>
 </body>
 </html>


### PR DESCRIPTION
Tightens the Eliminatorias bracket so it needs minimal zoom to see the whole cuadro.

- Removed `ET` from each node's time; added a legend note (and round-key) in the hint line.
- Round headers shortened: `16` (Dieciseisavos), `8` (Octavos), `4` (Cuartos), `SF` (Semifinal), `F` (Final).
- Date and time now stacked on two tiny lines so each column is only as wide as `3:00 PM` instead of `28 jun · 3:00 PM ET`.
- Tighter paddings, gaps, flag size, connector stubs and min-widths across columns and the center column.

`index.html`: cache-bust `v27` → `v28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_