### PR TITLE
Bracket: DDMM date, 24h time, tighter center column

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -219,14 +219,14 @@ body > * { position: relative; z-index: 1; }
 /* mirror the right half so flags face inward like the poster */
 .bround.right .bteam { flex-direction: row-reverse; }
 .bround.right .bteam .bsc { margin-left: 0; margin-right: auto; text-align: left; }
-/* center column: trophy + Final + champion + 3rd place */
-.center-col { min-width: 0; justify-content: center; align-items: stretch; padding: 0 4px; }
-.center-col .btrophy { font-size: 1.7rem; text-align: center; line-height: 1; margin-bottom: 2px; }
+/* center column: trophy + Final + champion + 3rd place (max compressed) */
+.center-col { min-width: 0; justify-content: center; align-items: stretch; padding: 0 3px; }
+.center-col .btrophy { font-size: 1.25rem; text-align: center; line-height: 1; margin-bottom: 1px; }
 .center-col .bmatch { border-color: var(--gold-deep); }
-.bchamp { display: flex; align-items: center; justify-content: center; gap: 5px; text-align: center; font-weight: 800; font-size: 0.78rem; color: var(--gold); margin-top: 6px;
-  background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 8px; padding: 9px 6px; }
-.bchamp .flag { font-size: 1.2rem; }
-.center-col .b3rdlabel { font-size: 0.62rem; color: var(--muted); text-align: center; margin: 10px 0 5px; text-transform: uppercase; letter-spacing: 0.02em; }
+.bchamp { display: flex; align-items: center; justify-content: center; gap: 3px; text-align: center; font-weight: 800; font-size: 0.56rem; color: var(--gold); margin-top: 4px;
+  background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 6px; padding: 5px 4px; }
+.bchamp .flag { font-size: 0.9rem; }
+.center-col .b3rdlabel { font-size: 0.54rem; color: var(--muted); text-align: center; margin: 6px 0 4px; text-transform: uppercase; letter-spacing: 0.01em; }
 
 /* Title Pie */
 .titlepie { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 12px; margin-bottom: 12px; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -163,18 +163,19 @@
     return new Date(ko).toLocaleTimeString("es-MX", { hour: "2-digit", minute: "2-digit" });
   }
 
-  // Compact "28 jun · 3:00 PM ET" for the knockout bracket nodes (Eastern time).
+  // Ultra-compact "2806" / "1700" (DDMM + 24h, Eastern time) for bracket nodes.
   function bracketWhen(m) {
     const ko = m.kickoff_utc ? (typeof m.kickoff_utc === "number" ? m.kickoff_utc : Date.parse(m.kickoff_utc)) : 0;
     if (ko) {
       const d = new Date(ko);
-      const dayStr = d.toLocaleDateString("es-MX", { timeZone: "America/New_York", day: "numeric", month: "short" });
-      const time = d.toLocaleTimeString("en-US", { timeZone: "America/New_York", hour: "numeric", minute: "2-digit", hour12: true });
-      return `<span class="bd-d">${dayStr}</span><span class="bd-t">${time}</span>`;
+      const ddmm = d.toLocaleDateString("en-GB", { timeZone: "America/New_York", day: "2-digit", month: "2-digit" }).replace("/", "");
+      const hhmm = d.toLocaleTimeString("en-GB", { timeZone: "America/New_York", hour: "2-digit", minute: "2-digit", hour12: false }).replace(":", "");
+      return `<span class="bd-d">${ddmm}</span><span class="bd-t">${hhmm}</span>`;
     }
     if (m.date) {
       const d = new Date(m.date + "T12:00:00");
-      return `<span class="bd-d">${d.getDate()} ${MONTHS[d.getMonth()]}</span>`;
+      const ddmm = String(d.getDate()).padStart(2, "0") + String(d.getMonth() + 1).padStart(2, "0");
+      return `<span class="bd-d">${ddmm}</span>`;
     }
     return "";
   }

--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=28"></script>
-  <script src="assets/js/odds.js?v=28"></script>
-  <script src="assets/js/data.js?v=28"></script>
-  <script src="assets/js/app.js?v=28"></script>
+  <script src="assets/js/scoring.js?v=29"></script>
+  <script src="assets/js/odds.js?v=29"></script>
+  <script src="assets/js/data.js?v=29"></script>
+  <script src="assets/js/app.js?v=29"></script>
 </body>
 </html>


### PR DESCRIPTION
Further compresses the Eliminatorias bracket nodes.

- Date now `DDMM` (e.g. `2806`) instead of `28 jun`.
- Time now 24h with no colon (e.g. `1500`) instead of `3:00 PM` (Eastern time, per the legend note).
- Center column maxed-out compression: smaller trophy, tighter paddings, and a smaller **Campeón** text/flag font.

`index.html`: cache-bust `v28` → `v29`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_