### PR TITLE
Bracket center: remove ¿? and compress champion box

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -220,13 +220,13 @@ body > * { position: relative; z-index: 1; }
 .bround.right .bteam { flex-direction: row-reverse; }
 .bround.right .bteam .bsc { margin-left: 0; margin-right: auto; text-align: left; }
 /* center column: trophy + Final + champion + 3rd place (max compressed) */
-.center-col { min-width: 0; justify-content: center; align-items: stretch; padding: 0 3px; }
-.center-col .btrophy { font-size: 1.25rem; text-align: center; line-height: 1; margin-bottom: 1px; }
+.center-col { min-width: 0; justify-content: center; align-items: stretch; padding: 0 2px; }
+.center-col .btrophy { font-size: 1.05rem; text-align: center; line-height: 1; margin-bottom: 1px; }
 .center-col .bmatch { border-color: var(--gold-deep); }
-.bchamp { display: flex; align-items: center; justify-content: center; gap: 3px; text-align: center; font-weight: 800; font-size: 0.56rem; color: var(--gold); margin-top: 4px;
-  background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 6px; padding: 5px 4px; }
-.bchamp .flag { font-size: 0.9rem; }
-.center-col .b3rdlabel { font-size: 0.54rem; color: var(--muted); text-align: center; margin: 6px 0 4px; text-transform: uppercase; letter-spacing: 0.01em; }
+.bchamp { display: flex; align-items: center; justify-content: center; gap: 2px; text-align: center; font-weight: 800; font-size: 0.48rem; color: var(--gold); margin-top: 3px;
+  background: linear-gradient(180deg, rgba(232,198,106,0.18), rgba(232,198,106,0.05)); border: 1px solid var(--gold-deep); border-radius: 5px; padding: 3px 3px; }
+.bchamp .flag { font-size: 0.8rem; }
+.center-col .b3rdlabel { font-size: 0.5rem; color: var(--muted); text-align: center; margin: 5px 0 3px; text-transform: uppercase; letter-spacing: 0.01em; }
 
 /* Title Pie */
 .titlepie { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 12px; margin-bottom: 12px; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -548,7 +548,7 @@
     const champBox = el("div", "bchamp");
     champBox.innerHTML = champ
       ? (state.teams[champ] ? `<span class="flag">${state.teams[champ].flag}</span> ${state.teams[champ].es}` : champ)
-      : "Campeón ¿?";
+      : "Campeón";
     center.appendChild(champBox);
     const tp = byNum[103];
     if (tp) {

--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=29"></script>
-  <script src="assets/js/odds.js?v=29"></script>
-  <script src="assets/js/data.js?v=29"></script>
-  <script src="assets/js/app.js?v=29"></script>
+  <script src="assets/js/scoring.js?v=30"></script>
+  <script src="assets/js/odds.js?v=30"></script>
+  <script src="assets/js/data.js?v=30"></script>
+  <script src="assets/js/app.js?v=30"></script>
 </body>
 </html>


### PR DESCRIPTION
Final polish on the center column of the Eliminatorias bracket.

- Removed the `¿?` from the **Campeón** box (shows just "Campeón" until decided).
- Smaller champion text + flag font.
- Tighter trophy, paddings and margins so the center is as compact as possible.

`index.html`: cache-bust `v29` → `v30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_