### PR TITLE
Show penalty-shootout results in the bracket

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -213,9 +213,10 @@ body > * { position: relative; z-index: 1; }
 .bteam .flag.proj { opacity: 0.5; }
 .bteam .bn { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .bteam .bn.ph { font-size: 0.68rem; color: var(--muted); }
-.bteam .bsc { font-weight: 800; color: var(--muted); min-width: 11px; text-align: right; margin-left: auto; }
+.bteam .bsc { font-weight: 800; color: var(--muted); min-width: 11px; text-align: right; margin-left: auto; white-space: nowrap; }
+.bteam .bpen { font-size: 0.78em; font-weight: 700; color: var(--muted); margin-left: 1px; }
 .bteam.bw { background: rgba(232, 198, 106, 0.12); }
-.bteam.bw .bsc { color: var(--gold); }
+.bteam.bw .bsc, .bteam.bw .bpen { color: var(--gold); }
 /* mirror the right half so flags face inward like the poster */
 .bround.right .bteam { flex-direction: row-reverse; }
 .bround.right .bteam .bsc { margin-left: 0; margin-right: auto; text-align: left; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -485,7 +485,8 @@
       return m ? code : "—";
     };
 
-    const brTeam = (code, score, win) => {
+    // pen = penalty-shootout count for this side (shown as "(4)"), or null.
+    const brTeam = (code, score, pen, win) => {
       const r = resolveSlot(code);
       let inner;
       if (r.name && state.teams[r.name]) {
@@ -494,15 +495,21 @@
       } else {
         inner = `<span class="bn ph">${slotShort(code)}</span>`;
       }
-      return `<div class="bteam ${win ? "bw" : ""}">${inner}<span class="bsc">${score != null ? score : ""}</span></div>`;
+      const penHTML = pen != null ? `<span class="bpen">(${pen})</span>` : "";
+      return `<div class="bteam ${win ? "bw" : ""}">${inner}<span class="bsc">${score != null ? score : ""}${penHTML}</span></div>`;
     };
     const bnode = (m) => {
       const fin = m.status === "finished" && m.score;
-      const w0 = fin && m.score[0] > m.score[1], w1 = fin && m.score[1] > m.score[0];
+      let w0 = false, w1 = false;
+      if (fin) {
+        if (m.score[0] !== m.score[1]) { w0 = m.score[0] > m.score[1]; w1 = !w0; }
+        else if (m.pens) { w0 = m.pens[0] > m.pens[1]; w1 = m.pens[1] > m.pens[0]; }
+      }
+      const p0 = m.pens ? m.pens[0] : null, p1 = m.pens ? m.pens[1] : null;
       const n = el("div", "bmatch" + (m.status === "live" ? " blive" : ""));
       const ds = bracketWhen(m);
       n.innerHTML = `<div class="bdate">${ds}</div>` +
-        brTeam(m.home, m.score ? m.score[0] : null, w0) + brTeam(m.away, m.score ? m.score[1] : null, w1);
+        brTeam(m.home, m.score ? m.score[0] : null, p0, w0) + brTeam(m.away, m.score ? m.score[1] : null, p1, w1);
       return n;
     };
 
@@ -540,8 +547,10 @@
     // Center: 🏆 + Final + Campeón + 3er lugar
     const final = byNum[104];
     let champ = null;
-    if (final && final.status === "finished" && final.score && final.score[0] !== final.score[1])
-      champ = final.score[0] > final.score[1] ? final.home : final.away;
+    if (final && final.status === "finished" && final.score) {
+      if (final.score[0] !== final.score[1]) champ = final.score[0] > final.score[1] ? final.home : final.away;
+      else if (final.pens) champ = final.pens[0] > final.pens[1] ? final.home : final.away;
+    }
     const center = el("div", "bround center-col");
     center.innerHTML = `<div class="btrophy">🏆</div><div class="brh">F</div>`;
     if (final) center.appendChild(bnode(final));

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -81,11 +81,13 @@
       const home = m.team1, away = m.team2, date = m.date;
       if (!home || !away || !date) continue;
       const ft = m.score && m.score.ft;
+      const pen = m.score && m.score.p; // penalty shootout result
       matches[`${date}|${home}|${away}`] = {
         num: m.num, // FIFA match number (knockout bracket tree)
         date, time: m.time, kickoff_utc: kickoffUtc(date, m.time),
         home, away, group: m.group, round: m.round, ground: m.ground,
         score: ft && ft.length === 2 ? [ft[0], ft[1]] : null,
+        pens: pen && pen.length === 2 ? [pen[0], pen[1]] : null,
         status: ft && ft.length === 2 ? "finished" : "scheduled",
         source: "openfootball",
       };

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-30T12:21:46.911195+00:00",
+  "generated_at": "2026-06-30T12:57:06.353108+00:00",
   "matches": {
     "2026-06-11|Mexico|South Africa": {
       "num": null,
@@ -15,8 +15,9 @@
         2,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-11|South Korea|Czech Republic": {
       "num": null,
@@ -32,8 +33,9 @@
         2,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Czech Republic|South Africa": {
       "num": null,
@@ -49,8 +51,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Mexico|South Korea": {
       "num": null,
@@ -66,8 +69,9 @@
         1,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Czech Republic|Mexico": {
       "num": null,
@@ -83,8 +87,9 @@
         0,
         3
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|South Africa|South Korea": {
       "num": null,
@@ -100,8 +105,9 @@
         1,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-12|Canada|Bosnia & Herzegovina": {
       "num": null,
@@ -117,8 +123,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Qatar|Switzerland": {
       "num": null,
@@ -134,8 +141,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Switzerland|Bosnia & Herzegovina": {
       "num": null,
@@ -151,8 +159,9 @@
         4,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Canada|Qatar": {
       "num": null,
@@ -168,8 +177,9 @@
         6,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Switzerland|Canada": {
       "num": null,
@@ -185,8 +195,9 @@
         2,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Bosnia & Herzegovina|Qatar": {
       "num": null,
@@ -202,8 +213,9 @@
         3,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Brazil|Morocco": {
       "num": null,
@@ -219,8 +231,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Haiti|Scotland": {
       "num": null,
@@ -236,8 +249,9 @@
         0,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|Scotland|Morocco": {
       "num": null,
@@ -253,8 +267,9 @@
         0,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|Brazil|Haiti": {
       "num": null,
@@ -270,8 +285,9 @@
         3,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Scotland|Brazil": {
       "num": null,
@@ -287,8 +303,9 @@
         0,
         3
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Morocco|Haiti": {
       "num": null,
@@ -304,8 +321,9 @@
         4,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-12|USA|Paraguay": {
       "num": null,
@@ -321,8 +339,9 @@
         4,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Australia|Turkey": {
       "num": null,
@@ -338,8 +357,9 @@
         2,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|USA|Australia": {
       "num": null,
@@ -355,8 +375,9 @@
         2,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|Turkey|Paraguay": {
       "num": null,
@@ -372,8 +393,9 @@
         0,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Turkey|USA": {
       "num": null,
@@ -389,8 +411,9 @@
         3,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Paraguay|Australia": {
       "num": null,
@@ -406,8 +429,9 @@
         0,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Germany|Curaçao": {
       "num": null,
@@ -423,8 +447,9 @@
         7,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Ivory Coast|Ecuador": {
       "num": null,
@@ -440,8 +465,9 @@
         1,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Germany|Ivory Coast": {
       "num": null,
@@ -457,8 +483,9 @@
         2,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Ecuador|Curaçao": {
       "num": null,
@@ -474,8 +501,9 @@
         0,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Curaçao|Ivory Coast": {
       "num": null,
@@ -491,8 +519,9 @@
         0,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Ecuador|Germany": {
       "num": null,
@@ -508,8 +537,9 @@
         2,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Netherlands|Japan": {
       "num": null,
@@ -525,8 +555,9 @@
         2,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Sweden|Tunisia": {
       "num": null,
@@ -542,8 +573,9 @@
         5,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Netherlands|Sweden": {
       "num": null,
@@ -559,8 +591,9 @@
         5,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Tunisia|Japan": {
       "num": null,
@@ -576,8 +609,9 @@
         0,
         4
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Japan|Sweden": {
       "num": null,
@@ -593,8 +627,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Tunisia|Netherlands": {
       "num": null,
@@ -610,8 +645,9 @@
         1,
         3
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Belgium|Egypt": {
       "num": null,
@@ -627,8 +663,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Iran|New Zealand": {
       "num": null,
@@ -644,8 +681,9 @@
         2,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Belgium|Iran": {
       "num": null,
@@ -661,8 +699,9 @@
         0,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|New Zealand|Egypt": {
       "num": null,
@@ -678,8 +717,9 @@
         1,
         3
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Egypt|Iran": {
       "num": null,
@@ -695,8 +735,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|New Zealand|Belgium": {
       "num": null,
@@ -712,8 +753,9 @@
         1,
         5
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Spain|Cape Verde": {
       "num": null,
@@ -729,8 +771,9 @@
         0,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Saudi Arabia|Uruguay": {
       "num": null,
@@ -746,8 +789,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Spain|Saudi Arabia": {
       "num": null,
@@ -763,8 +807,9 @@
         4,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Uruguay|Cape Verde": {
       "num": null,
@@ -780,8 +825,9 @@
         2,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Cape Verde|Saudi Arabia": {
       "num": null,
@@ -797,8 +843,9 @@
         0,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Uruguay|Spain": {
       "num": null,
@@ -814,8 +861,9 @@
         0,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|France|Senegal": {
       "num": null,
@@ -831,8 +879,9 @@
         3,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Iraq|Norway": {
       "num": null,
@@ -848,8 +897,9 @@
         1,
         4
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|France|Iraq": {
       "num": null,
@@ -865,8 +915,9 @@
         3,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|Norway|Senegal": {
       "num": null,
@@ -882,8 +933,9 @@
         3,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Norway|France": {
       "num": null,
@@ -899,8 +951,9 @@
         1,
         4
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Senegal|Iraq": {
       "num": null,
@@ -916,8 +969,9 @@
         5,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Argentina|Algeria": {
       "num": null,
@@ -933,8 +987,9 @@
         3,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Austria|Jordan": {
       "num": null,
@@ -950,8 +1005,9 @@
         3,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|Argentina|Austria": {
       "num": null,
@@ -967,8 +1023,9 @@
         2,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|Jordan|Algeria": {
       "num": null,
@@ -984,8 +1041,9 @@
         1,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Algeria|Austria": {
       "num": null,
@@ -1001,8 +1059,9 @@
         3,
         3
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Jordan|Argentina": {
       "num": null,
@@ -1018,8 +1077,9 @@
         1,
         3
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Portugal|DR Congo": {
       "num": null,
@@ -1035,8 +1095,9 @@
         1,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Uzbekistan|Colombia": {
       "num": null,
@@ -1052,8 +1113,9 @@
         1,
         3
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|Portugal|Uzbekistan": {
       "num": null,
@@ -1069,8 +1131,9 @@
         5,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|Colombia|DR Congo": {
       "num": null,
@@ -1086,8 +1149,9 @@
         1,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Colombia|Portugal": {
       "num": null,
@@ -1103,8 +1167,9 @@
         0,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|DR Congo|Uzbekistan": {
       "num": null,
@@ -1120,8 +1185,9 @@
         3,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|England|Croatia": {
       "num": null,
@@ -1137,8 +1203,9 @@
         4,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Ghana|Panama": {
       "num": null,
@@ -1154,8 +1221,9 @@
         1,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|England|Ghana": {
       "num": null,
@@ -1171,8 +1239,9 @@
         0,
         0
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|Panama|Croatia": {
       "num": null,
@@ -1188,8 +1257,9 @@
         0,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Panama|England": {
       "num": null,
@@ -1205,8 +1275,9 @@
         0,
         2
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Croatia|Ghana": {
       "num": null,
@@ -1222,8 +1293,9 @@
         2,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-28|South Africa|Canada": {
       "num": 73,
@@ -1239,8 +1311,9 @@
         0,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-29|Germany|Paraguay": {
       "num": 74,
@@ -1256,8 +1329,12 @@
         1,
         1
       ],
+      "pens": [
+        3,
+        4
+      ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-29|Netherlands|Morocco": {
       "num": 75,
@@ -1273,8 +1350,12 @@
         1,
         1
       ],
+      "pens": [
+        2,
+        3
+      ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-29|Brazil|Japan": {
       "num": 76,
@@ -1290,8 +1371,9 @@
         2,
         1
       ],
+      "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-30|France|Sweden": {
       "num": 77,
@@ -1304,6 +1386,7 @@
       "round": "Round of 32",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1318,6 +1401,7 @@
       "round": "Round of 32",
       "ground": "Dallas (Arlington)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1332,6 +1416,7 @@
       "round": "Round of 32",
       "ground": "Mexico City",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1346,6 +1431,7 @@
       "round": "Round of 32",
       "ground": "Atlanta",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1360,6 +1446,7 @@
       "round": "Round of 32",
       "ground": "San Francisco Bay Area (Santa Clara)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1374,6 +1461,7 @@
       "round": "Round of 32",
       "ground": "Seattle",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1388,6 +1476,7 @@
       "round": "Round of 32",
       "ground": "Toronto",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1402,6 +1491,7 @@
       "round": "Round of 32",
       "ground": "Los Angeles (Inglewood)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1416,6 +1506,7 @@
       "round": "Round of 32",
       "ground": "Vancouver",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1430,6 +1521,7 @@
       "round": "Round of 32",
       "ground": "Miami (Miami Gardens)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1444,6 +1536,7 @@
       "round": "Round of 32",
       "ground": "Kansas City",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1458,6 +1551,7 @@
       "round": "Round of 32",
       "ground": "Dallas (Arlington)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1472,6 +1566,7 @@
       "round": "Round of 16",
       "ground": "Philadelphia",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1486,6 +1581,7 @@
       "round": "Round of 16",
       "ground": "Houston",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1500,6 +1596,7 @@
       "round": "Round of 16",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1514,6 +1611,7 @@
       "round": "Round of 16",
       "ground": "Mexico City",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1528,6 +1626,7 @@
       "round": "Round of 16",
       "ground": "Dallas (Arlington)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1542,6 +1641,7 @@
       "round": "Round of 16",
       "ground": "Seattle",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1556,6 +1656,7 @@
       "round": "Round of 16",
       "ground": "Atlanta",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1570,6 +1671,7 @@
       "round": "Round of 16",
       "ground": "Vancouver",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1584,6 +1686,7 @@
       "round": "Quarter-final",
       "ground": "Boston (Foxborough)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1598,6 +1701,7 @@
       "round": "Quarter-final",
       "ground": "Los Angeles (Inglewood)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1612,6 +1716,7 @@
       "round": "Quarter-final",
       "ground": "Miami (Miami Gardens)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1626,6 +1731,7 @@
       "round": "Quarter-final",
       "ground": "Kansas City",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1640,6 +1746,7 @@
       "round": "Semi-final",
       "ground": "Dallas (Arlington)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1654,6 +1761,7 @@
       "round": "Semi-final",
       "ground": "Atlanta",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1668,6 +1776,7 @@
       "round": "Match for third place",
       "ground": "Miami (Miami Gardens)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     },
@@ -1682,6 +1791,7 @@
       "round": "Final",
       "ground": "New York/New Jersey (East Rutherford)",
       "score": null,
+      "pens": null,
       "status": "scheduled",
       "source": "openfootball"
     }

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-30T12:57:06.353108+00:00",
+  "generated_at": "2026-06-30T12:57:46.331308+00:00",
   "matches": {
     "2026-06-11|Mexico|South Africa": {
       "num": null,
@@ -17,7 +17,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-11|South Korea|Czech Republic": {
       "num": null,
@@ -35,7 +35,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Czech Republic|South Africa": {
       "num": null,
@@ -53,7 +53,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Mexico|South Korea": {
       "num": null,
@@ -71,7 +71,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Czech Republic|Mexico": {
       "num": null,
@@ -89,7 +89,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|South Africa|South Korea": {
       "num": null,
@@ -107,7 +107,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-12|Canada|Bosnia & Herzegovina": {
       "num": null,
@@ -125,7 +125,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Qatar|Switzerland": {
       "num": null,
@@ -143,7 +143,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Switzerland|Bosnia & Herzegovina": {
       "num": null,
@@ -161,7 +161,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Canada|Qatar": {
       "num": null,
@@ -179,7 +179,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Switzerland|Canada": {
       "num": null,
@@ -197,7 +197,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Bosnia & Herzegovina|Qatar": {
       "num": null,
@@ -215,7 +215,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Brazil|Morocco": {
       "num": null,
@@ -233,7 +233,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Haiti|Scotland": {
       "num": null,
@@ -251,7 +251,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|Scotland|Morocco": {
       "num": null,
@@ -269,7 +269,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|Brazil|Haiti": {
       "num": null,
@@ -287,7 +287,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Scotland|Brazil": {
       "num": null,
@@ -305,7 +305,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Morocco|Haiti": {
       "num": null,
@@ -323,7 +323,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-12|USA|Paraguay": {
       "num": null,
@@ -341,7 +341,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Australia|Turkey": {
       "num": null,
@@ -359,7 +359,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|USA|Australia": {
       "num": null,
@@ -377,7 +377,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|Turkey|Paraguay": {
       "num": null,
@@ -395,7 +395,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Turkey|USA": {
       "num": null,
@@ -413,7 +413,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Paraguay|Australia": {
       "num": null,
@@ -431,7 +431,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Germany|Curaçao": {
       "num": null,
@@ -449,7 +449,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Ivory Coast|Ecuador": {
       "num": null,
@@ -467,7 +467,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Germany|Ivory Coast": {
       "num": null,
@@ -485,7 +485,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Ecuador|Curaçao": {
       "num": null,
@@ -503,7 +503,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Curaçao|Ivory Coast": {
       "num": null,
@@ -521,7 +521,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Ecuador|Germany": {
       "num": null,
@@ -539,7 +539,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Netherlands|Japan": {
       "num": null,
@@ -557,7 +557,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Sweden|Tunisia": {
       "num": null,
@@ -575,7 +575,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Netherlands|Sweden": {
       "num": null,
@@ -593,7 +593,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Tunisia|Japan": {
       "num": null,
@@ -611,7 +611,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Japan|Sweden": {
       "num": null,
@@ -629,7 +629,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Tunisia|Netherlands": {
       "num": null,
@@ -647,7 +647,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Belgium|Egypt": {
       "num": null,
@@ -665,7 +665,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Iran|New Zealand": {
       "num": null,
@@ -683,7 +683,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|Belgium|Iran": {
       "num": null,
@@ -701,7 +701,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|New Zealand|Egypt": {
       "num": null,
@@ -719,7 +719,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Egypt|Iran": {
       "num": null,
@@ -737,7 +737,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|New Zealand|Belgium": {
       "num": null,
@@ -755,7 +755,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Spain|Cape Verde": {
       "num": null,
@@ -773,7 +773,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Saudi Arabia|Uruguay": {
       "num": null,
@@ -791,7 +791,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|Spain|Saudi Arabia": {
       "num": null,
@@ -809,7 +809,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|Uruguay|Cape Verde": {
       "num": null,
@@ -827,7 +827,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Cape Verde|Saudi Arabia": {
       "num": null,
@@ -845,7 +845,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Uruguay|Spain": {
       "num": null,
@@ -863,7 +863,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|France|Senegal": {
       "num": null,
@@ -881,7 +881,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|Iraq|Norway": {
       "num": null,
@@ -899,7 +899,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|France|Iraq": {
       "num": null,
@@ -917,7 +917,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|Norway|Senegal": {
       "num": null,
@@ -935,7 +935,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Norway|France": {
       "num": null,
@@ -953,7 +953,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Senegal|Iraq": {
       "num": null,
@@ -971,7 +971,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|Argentina|Algeria": {
       "num": null,
@@ -989,7 +989,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|Austria|Jordan": {
       "num": null,
@@ -1007,7 +1007,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|Argentina|Austria": {
       "num": null,
@@ -1025,7 +1025,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|Jordan|Algeria": {
       "num": null,
@@ -1043,7 +1043,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Algeria|Austria": {
       "num": null,
@@ -1061,7 +1061,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Jordan|Argentina": {
       "num": null,
@@ -1079,7 +1079,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|Portugal|DR Congo": {
       "num": null,
@@ -1097,7 +1097,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|Uzbekistan|Colombia": {
       "num": null,
@@ -1115,7 +1115,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|Portugal|Uzbekistan": {
       "num": null,
@@ -1133,7 +1133,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|Colombia|DR Congo": {
       "num": null,
@@ -1151,7 +1151,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Colombia|Portugal": {
       "num": null,
@@ -1169,7 +1169,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|DR Congo|Uzbekistan": {
       "num": null,
@@ -1187,7 +1187,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|England|Croatia": {
       "num": null,
@@ -1205,7 +1205,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|Ghana|Panama": {
       "num": null,
@@ -1223,7 +1223,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|England|Ghana": {
       "num": null,
@@ -1241,7 +1241,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|Panama|Croatia": {
       "num": null,
@@ -1259,7 +1259,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Panama|England": {
       "num": null,
@@ -1277,7 +1277,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Croatia|Ghana": {
       "num": null,
@@ -1295,7 +1295,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-28|South Africa|Canada": {
       "num": 73,
@@ -1313,7 +1313,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-29|Germany|Paraguay": {
       "num": 74,
@@ -1334,7 +1334,7 @@
         4
       ],
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-29|Netherlands|Morocco": {
       "num": 75,
@@ -1355,7 +1355,7 @@
         3
       ],
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-29|Brazil|Japan": {
       "num": 76,
@@ -1373,7 +1373,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-30|France|Sweden": {
       "num": 77,

--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=30"></script>
-  <script src="assets/js/odds.js?v=30"></script>
-  <script src="assets/js/data.js?v=30"></script>
-  <script src="assets/js/app.js?v=30"></script>
+  <script src="assets/js/scoring.js?v=31"></script>
+  <script src="assets/js/odds.js?v=31"></script>
+  <script src="assets/js/data.js?v=31"></script>
+  <script src="assets/js/app.js?v=31"></script>
 </body>
 </html>

--- a/scripts/fetch_results.py
+++ b/scripts/fetch_results.py
@@ -96,6 +96,7 @@ def normalize_openfootball(data):
             continue
         score = m.get("score") or {}
         ft = score.get("ft")
+        pen = score.get("p")  # penalty shootout result, when a KO match is decided on pens
         key = f"{date}|{home}|{away}"
         out[key] = {
             "num": m.get("num"),  # FIFA match number (drives the knockout bracket tree)
@@ -108,6 +109,7 @@ def normalize_openfootball(data):
             "round": m.get("round"),
             "ground": m.get("ground"),
             "score": [ft[0], ft[1]] if ft and len(ft) == 2 else None,
+            "pens": [pen[0], pen[1]] if pen and len(pen) == 2 else None,
             "status": "finished" if ft and len(ft) == 2 else "scheduled",
             "source": "openfootball",
         }


### PR DESCRIPTION
Adds penalty-shootout results to the Eliminatorias bracket, using the notation from the example: **Germany (3) 1 - 1 (4) Paraguay**.

- Each side's score now shows the penalty count in parentheses, e.g. `1 (4)`, when a knockout match is decided on penalties.
- The winning team (highlighted gold) and the **Campeón** are determined by penalties when regulation/extra time is level.
- Penalty data (`score.p`) is captured through `fetch_results.py` and the `data.js` client fallback, and backfilled into `data/results.json` (e.g. Paraguay 4-3 over Germany, Morocco 3-2 over Netherlands).

`index.html`: cache-bust `v30` → `v31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_