### PR TITLE
Keep bracket current (client openfootball overlay) + extra-time scores

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -80,15 +80,16 @@
     for (const m of feed.matches || []) {
       const home = m.team1, away = m.team2, date = m.date;
       if (!home || !away || !date) continue;
-      const ft = m.score && m.score.ft;
-      const pen = m.score && m.score.p; // penalty shootout result
+      const sc = m.score || {};
+      const final = sc.et && sc.et.length === 2 ? sc.et : sc.ft; // ET result if it went to extra time
+      const pen = sc.p; // penalty shootout result
       matches[`${date}|${home}|${away}`] = {
         num: m.num, // FIFA match number (knockout bracket tree)
         date, time: m.time, kickoff_utc: kickoffUtc(date, m.time),
         home, away, group: m.group, round: m.round, ground: m.ground,
-        score: ft && ft.length === 2 ? [ft[0], ft[1]] : null,
+        score: final && final.length === 2 ? [final[0], final[1]] : null,
         pens: pen && pen.length === 2 ? [pen[0], pen[1]] : null,
-        status: ft && ft.length === 2 ? "finished" : "scheduled",
+        status: final && final.length === 2 ? "finished" : "scheduled",
         source: "openfootball",
       };
     }
@@ -198,6 +199,39 @@
     return n;
   }
 
+  // Overlay the openfootball feed (CORS-enabled, authoritative for FINISHED
+  // matches incl. penalties, and it resolves knockout slots to real teams) onto
+  // whatever we loaded, joining by FIFA match number so it works even when a
+  // committed KO match still shows a "W83" code. This keeps the site current even
+  // if the scheduled Action that commits results.json is late. Best-effort.
+  async function overlayOpenfootball(results) {
+    const feed = await fetchJSONTimed(OPENFOOTBALL_URL, 8000);
+    if (!feed || !feed.matches) return false;
+    const byNum = {};
+    for (const m of Object.values(results.matches)) if (m.num != null) byNum[m.num] = m;
+    let changed = 0;
+    for (const fm of feed.matches) {
+      const t = fm.num != null ? byNum[fm.num] : null;
+      if (!t) continue;
+      // Fill in knockout teams once openfootball has resolved the slot codes.
+      if (fm.team1 && fm.team2) {
+        if (t.home !== fm.team1) { t.home = fm.team1; changed++; }
+        if (t.away !== fm.team2) { t.away = fm.team2; changed++; }
+      }
+      const sc = fm.score || {};
+      const ft = sc.et && sc.et.length === 2 ? sc.et : sc.ft; // ET result if it went to extra time
+      const pen = sc.p;
+      if (ft && ft.length === 2) {
+        if (!t.score || t.score[0] !== ft[0] || t.score[1] !== ft[1]) { t.score = [ft[0], ft[1]]; changed++; }
+        if (pen && pen.length === 2 && (!t.pens || t.pens[0] !== pen[0] || t.pens[1] !== pen[1])) { t.pens = [pen[0], pen[1]]; changed++; }
+        if (t.status !== "finished") { t.status = "finished"; changed++; }
+        t.source = t.source === "live" ? t.source : "openfootball";
+      }
+    }
+    if (changed) results.generated_at = new Date().toISOString();
+    return changed > 0;
+  }
+
   // Best-effort live overlay. Tries ESPN first (reliable), then worldcup26 via the
   // configured Worker / public proxies. Never throws; on failure keeps committed data.
   async function overlayLiveClient(results) {
@@ -256,9 +290,12 @@
   // Overlay live scores onto already-loaded results, then re-apply the clock.
   // Returns true if anything changed (so the caller can re-render). Best-effort.
   async function applyLive(results) {
-    const changed = await overlayLiveClient(results);
+    // openfootball first (finished results + resolved KO teams), then the live
+    // in-play sources (ESPN / worldcup26) on top for minute-by-minute scores.
+    const off = await overlayOpenfootball(results);
+    const live = await overlayLiveClient(results);
     applyClock(results);
-    return changed;
+    return off || live;
   }
 
   global.DataLayer = { load, applyLive };

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-07T18:47:33.134637+00:00",
+  "generated_at": "2026-07-07T18:48:02.635858+00:00",
   "matches": {
     "2026-06-11|Mexico|South Africa": {
       "num": null,
@@ -17,7 +17,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-11|South Korea|Czech Republic": {
       "num": null,
@@ -35,7 +35,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Czech Republic|South Africa": {
       "num": null,
@@ -53,7 +53,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Mexico|South Korea": {
       "num": null,
@@ -71,7 +71,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Czech Republic|Mexico": {
       "num": null,
@@ -89,7 +89,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|South Africa|South Korea": {
       "num": null,
@@ -107,7 +107,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-12|Canada|Bosnia & Herzegovina": {
       "num": null,
@@ -125,7 +125,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Qatar|Switzerland": {
       "num": null,
@@ -143,7 +143,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Switzerland|Bosnia & Herzegovina": {
       "num": null,
@@ -161,7 +161,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-18|Canada|Qatar": {
       "num": null,
@@ -179,7 +179,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Switzerland|Canada": {
       "num": null,
@@ -197,7 +197,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Bosnia & Herzegovina|Qatar": {
       "num": null,
@@ -215,7 +215,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Brazil|Morocco": {
       "num": null,
@@ -233,7 +233,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Haiti|Scotland": {
       "num": null,
@@ -251,7 +251,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|Scotland|Morocco": {
       "num": null,
@@ -269,7 +269,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|Brazil|Haiti": {
       "num": null,
@@ -287,7 +287,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Scotland|Brazil": {
       "num": null,
@@ -305,7 +305,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-24|Morocco|Haiti": {
       "num": null,
@@ -323,7 +323,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-12|USA|Paraguay": {
       "num": null,
@@ -341,7 +341,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-13|Australia|Turkey": {
       "num": null,
@@ -359,7 +359,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|USA|Australia": {
       "num": null,
@@ -377,7 +377,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-19|Turkey|Paraguay": {
       "num": null,
@@ -395,7 +395,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Turkey|USA": {
       "num": null,
@@ -413,7 +413,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Paraguay|Australia": {
       "num": null,
@@ -431,7 +431,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Germany|Curaçao": {
       "num": null,
@@ -449,7 +449,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Ivory Coast|Ecuador": {
       "num": null,
@@ -467,7 +467,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Germany|Ivory Coast": {
       "num": null,
@@ -485,7 +485,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Ecuador|Curaçao": {
       "num": null,
@@ -503,7 +503,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Curaçao|Ivory Coast": {
       "num": null,
@@ -521,7 +521,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Ecuador|Germany": {
       "num": null,
@@ -539,7 +539,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Netherlands|Japan": {
       "num": null,
@@ -557,7 +557,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-14|Sweden|Tunisia": {
       "num": null,
@@ -575,7 +575,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Netherlands|Sweden": {
       "num": null,
@@ -593,7 +593,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-20|Tunisia|Japan": {
       "num": null,
@@ -611,7 +611,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Japan|Sweden": {
       "num": null,
@@ -629,7 +629,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-25|Tunisia|Netherlands": {
       "num": null,
@@ -647,7 +647,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Belgium|Egypt": {
       "num": null,
@@ -665,7 +665,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Iran|New Zealand": {
       "num": null,
@@ -683,7 +683,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|Belgium|Iran": {
       "num": null,
@@ -701,7 +701,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|New Zealand|Egypt": {
       "num": null,
@@ -719,7 +719,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Egypt|Iran": {
       "num": null,
@@ -737,7 +737,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|New Zealand|Belgium": {
       "num": null,
@@ -755,7 +755,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Spain|Cape Verde": {
       "num": null,
@@ -773,7 +773,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-15|Saudi Arabia|Uruguay": {
       "num": null,
@@ -791,7 +791,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|Spain|Saudi Arabia": {
       "num": null,
@@ -809,7 +809,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-21|Uruguay|Cape Verde": {
       "num": null,
@@ -827,7 +827,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Cape Verde|Saudi Arabia": {
       "num": null,
@@ -845,7 +845,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Uruguay|Spain": {
       "num": null,
@@ -863,7 +863,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|France|Senegal": {
       "num": null,
@@ -881,7 +881,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|Iraq|Norway": {
       "num": null,
@@ -899,7 +899,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|France|Iraq": {
       "num": null,
@@ -917,7 +917,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|Norway|Senegal": {
       "num": null,
@@ -935,7 +935,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Norway|France": {
       "num": null,
@@ -953,7 +953,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-26|Senegal|Iraq": {
       "num": null,
@@ -971,7 +971,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|Argentina|Algeria": {
       "num": null,
@@ -989,7 +989,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-16|Austria|Jordan": {
       "num": null,
@@ -1007,7 +1007,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|Argentina|Austria": {
       "num": null,
@@ -1025,7 +1025,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-22|Jordan|Algeria": {
       "num": null,
@@ -1043,7 +1043,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Algeria|Austria": {
       "num": null,
@@ -1061,7 +1061,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Jordan|Argentina": {
       "num": null,
@@ -1079,7 +1079,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|Portugal|DR Congo": {
       "num": null,
@@ -1097,7 +1097,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|Uzbekistan|Colombia": {
       "num": null,
@@ -1115,7 +1115,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|Portugal|Uzbekistan": {
       "num": null,
@@ -1133,7 +1133,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|Colombia|DR Congo": {
       "num": null,
@@ -1151,7 +1151,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Colombia|Portugal": {
       "num": null,
@@ -1169,7 +1169,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|DR Congo|Uzbekistan": {
       "num": null,
@@ -1187,7 +1187,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|England|Croatia": {
       "num": null,
@@ -1205,7 +1205,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-17|Ghana|Panama": {
       "num": null,
@@ -1223,7 +1223,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|England|Ghana": {
       "num": null,
@@ -1241,7 +1241,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-23|Panama|Croatia": {
       "num": null,
@@ -1259,7 +1259,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Panama|England": {
       "num": null,
@@ -1277,7 +1277,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-27|Croatia|Ghana": {
       "num": null,
@@ -1295,7 +1295,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-28|South Africa|Canada": {
       "num": 73,
@@ -1313,7 +1313,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-29|Germany|Paraguay": {
       "num": 74,
@@ -1334,7 +1334,7 @@
         4
       ],
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-29|Netherlands|Morocco": {
       "num": 75,
@@ -1355,7 +1355,7 @@
         3
       ],
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-29|Brazil|Japan": {
       "num": 76,
@@ -1373,7 +1373,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-30|France|Sweden": {
       "num": 77,
@@ -1391,7 +1391,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-30|Ivory Coast|Norway": {
       "num": 78,
@@ -1409,7 +1409,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-06-30|Mexico|Ecuador": {
       "num": 79,
@@ -1427,7 +1427,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-01|England|DR Congo": {
       "num": 80,
@@ -1445,7 +1445,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-01|USA|Bosnia & Herzegovina": {
       "num": 81,
@@ -1463,7 +1463,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-01|Belgium|Senegal": {
       "num": 82,
@@ -1481,7 +1481,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-02|Portugal|Croatia": {
       "num": 83,
@@ -1499,7 +1499,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-02|Spain|Austria": {
       "num": 84,
@@ -1517,7 +1517,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-02|Switzerland|Algeria": {
       "num": 85,
@@ -1535,7 +1535,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-03|Argentina|Cape Verde": {
       "num": 86,
@@ -1553,7 +1553,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-03|Colombia|Ghana": {
       "num": 87,
@@ -1571,7 +1571,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-03|Australia|Egypt": {
       "num": 88,
@@ -1592,7 +1592,7 @@
         4
       ],
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-04|Paraguay|France": {
       "num": 89,
@@ -1610,7 +1610,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-04|Canada|Morocco": {
       "num": 90,
@@ -1628,7 +1628,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-05|Brazil|Norway": {
       "num": 91,
@@ -1646,7 +1646,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-05|Mexico|England": {
       "num": 92,
@@ -1664,7 +1664,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-06|Portugal|Spain": {
       "num": 93,
@@ -1682,7 +1682,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-06|USA|Belgium": {
       "num": 94,
@@ -1700,7 +1700,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-07|Argentina|Egypt": {
       "num": 95,
@@ -1718,7 +1718,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "openfootball"
+      "source": "live"
     },
     "2026-07-07|Switzerland|Colombia": {
       "num": 96,

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-07T18:24:27.589358+00:00",
+  "generated_at": "2026-07-07T18:47:33.134637+00:00",
   "matches": {
     "2026-06-11|Mexico|South Africa": {
       "num": null,
@@ -17,7 +17,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-11|South Korea|Czech Republic": {
       "num": null,
@@ -35,7 +35,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Czech Republic|South Africa": {
       "num": null,
@@ -53,7 +53,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Mexico|South Korea": {
       "num": null,
@@ -71,7 +71,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Czech Republic|Mexico": {
       "num": null,
@@ -89,7 +89,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|South Africa|South Korea": {
       "num": null,
@@ -107,7 +107,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-12|Canada|Bosnia & Herzegovina": {
       "num": null,
@@ -125,7 +125,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Qatar|Switzerland": {
       "num": null,
@@ -143,7 +143,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Switzerland|Bosnia & Herzegovina": {
       "num": null,
@@ -161,7 +161,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-18|Canada|Qatar": {
       "num": null,
@@ -179,7 +179,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Switzerland|Canada": {
       "num": null,
@@ -197,7 +197,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Bosnia & Herzegovina|Qatar": {
       "num": null,
@@ -215,7 +215,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Brazil|Morocco": {
       "num": null,
@@ -233,7 +233,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Haiti|Scotland": {
       "num": null,
@@ -251,7 +251,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|Scotland|Morocco": {
       "num": null,
@@ -269,7 +269,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|Brazil|Haiti": {
       "num": null,
@@ -287,7 +287,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Scotland|Brazil": {
       "num": null,
@@ -305,7 +305,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-24|Morocco|Haiti": {
       "num": null,
@@ -323,7 +323,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-12|USA|Paraguay": {
       "num": null,
@@ -341,7 +341,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-13|Australia|Turkey": {
       "num": null,
@@ -359,7 +359,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|USA|Australia": {
       "num": null,
@@ -377,7 +377,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-19|Turkey|Paraguay": {
       "num": null,
@@ -395,7 +395,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Turkey|USA": {
       "num": null,
@@ -413,7 +413,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Paraguay|Australia": {
       "num": null,
@@ -431,7 +431,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Germany|Curaçao": {
       "num": null,
@@ -449,7 +449,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Ivory Coast|Ecuador": {
       "num": null,
@@ -467,7 +467,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Germany|Ivory Coast": {
       "num": null,
@@ -485,7 +485,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Ecuador|Curaçao": {
       "num": null,
@@ -503,7 +503,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Curaçao|Ivory Coast": {
       "num": null,
@@ -521,7 +521,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Ecuador|Germany": {
       "num": null,
@@ -539,7 +539,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Netherlands|Japan": {
       "num": null,
@@ -557,7 +557,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-14|Sweden|Tunisia": {
       "num": null,
@@ -575,7 +575,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Netherlands|Sweden": {
       "num": null,
@@ -593,7 +593,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-20|Tunisia|Japan": {
       "num": null,
@@ -611,7 +611,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Japan|Sweden": {
       "num": null,
@@ -629,7 +629,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-25|Tunisia|Netherlands": {
       "num": null,
@@ -647,7 +647,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Belgium|Egypt": {
       "num": null,
@@ -665,7 +665,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Iran|New Zealand": {
       "num": null,
@@ -683,7 +683,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Belgium|Iran": {
       "num": null,
@@ -701,7 +701,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|New Zealand|Egypt": {
       "num": null,
@@ -719,7 +719,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Egypt|Iran": {
       "num": null,
@@ -737,7 +737,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|New Zealand|Belgium": {
       "num": null,
@@ -755,7 +755,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Spain|Cape Verde": {
       "num": null,
@@ -773,7 +773,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-15|Saudi Arabia|Uruguay": {
       "num": null,
@@ -791,7 +791,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Spain|Saudi Arabia": {
       "num": null,
@@ -809,7 +809,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-21|Uruguay|Cape Verde": {
       "num": null,
@@ -827,7 +827,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Cape Verde|Saudi Arabia": {
       "num": null,
@@ -845,7 +845,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Uruguay|Spain": {
       "num": null,
@@ -863,7 +863,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|France|Senegal": {
       "num": null,
@@ -881,7 +881,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Iraq|Norway": {
       "num": null,
@@ -899,7 +899,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|France|Iraq": {
       "num": null,
@@ -917,7 +917,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|Norway|Senegal": {
       "num": null,
@@ -935,7 +935,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Norway|France": {
       "num": null,
@@ -953,7 +953,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-26|Senegal|Iraq": {
       "num": null,
@@ -971,7 +971,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Argentina|Algeria": {
       "num": null,
@@ -989,7 +989,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-16|Austria|Jordan": {
       "num": null,
@@ -1007,7 +1007,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|Argentina|Austria": {
       "num": null,
@@ -1025,7 +1025,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-22|Jordan|Algeria": {
       "num": null,
@@ -1043,7 +1043,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Algeria|Austria": {
       "num": null,
@@ -1061,7 +1061,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Jordan|Argentina": {
       "num": null,
@@ -1079,7 +1079,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Portugal|DR Congo": {
       "num": null,
@@ -1097,7 +1097,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Uzbekistan|Colombia": {
       "num": null,
@@ -1115,7 +1115,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|Portugal|Uzbekistan": {
       "num": null,
@@ -1133,7 +1133,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|Colombia|DR Congo": {
       "num": null,
@@ -1151,7 +1151,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Colombia|Portugal": {
       "num": null,
@@ -1169,7 +1169,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|DR Congo|Uzbekistan": {
       "num": null,
@@ -1187,7 +1187,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|England|Croatia": {
       "num": null,
@@ -1205,7 +1205,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-17|Ghana|Panama": {
       "num": null,
@@ -1223,7 +1223,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|England|Ghana": {
       "num": null,
@@ -1241,7 +1241,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-23|Panama|Croatia": {
       "num": null,
@@ -1259,7 +1259,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Panama|England": {
       "num": null,
@@ -1277,7 +1277,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-27|Croatia|Ghana": {
       "num": null,
@@ -1295,7 +1295,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-28|South Africa|Canada": {
       "num": 73,
@@ -1313,7 +1313,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-29|Germany|Paraguay": {
       "num": 74,
@@ -1334,7 +1334,7 @@
         4
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-29|Netherlands|Morocco": {
       "num": 75,
@@ -1355,7 +1355,7 @@
         3
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-29|Brazil|Japan": {
       "num": 76,
@@ -1373,7 +1373,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-30|France|Sweden": {
       "num": 77,
@@ -1391,7 +1391,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-30|Ivory Coast|Norway": {
       "num": 78,
@@ -1409,7 +1409,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-06-30|Mexico|Ecuador": {
       "num": 79,
@@ -1427,7 +1427,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-01|England|DR Congo": {
       "num": 80,
@@ -1445,7 +1445,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-01|USA|Bosnia & Herzegovina": {
       "num": 81,
@@ -1463,7 +1463,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-01|Belgium|Senegal": {
       "num": 82,
@@ -1481,7 +1481,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-02|Portugal|Croatia": {
       "num": 83,
@@ -1499,7 +1499,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-02|Spain|Austria": {
       "num": 84,
@@ -1517,7 +1517,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-02|Switzerland|Algeria": {
       "num": 85,
@@ -1535,7 +1535,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-03|Argentina|Cape Verde": {
       "num": 86,
@@ -1553,7 +1553,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-03|Colombia|Ghana": {
       "num": 87,
@@ -1571,7 +1571,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-03|Australia|Egypt": {
       "num": 88,
@@ -1592,7 +1592,7 @@
         4
       ],
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-04|Paraguay|France": {
       "num": 89,
@@ -1610,7 +1610,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-04|Canada|Morocco": {
       "num": 90,
@@ -1628,7 +1628,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-05|Brazil|Norway": {
       "num": 91,
@@ -1646,7 +1646,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-05|Mexico|England": {
       "num": 92,
@@ -1664,7 +1664,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-06|Portugal|Spain": {
       "num": 93,
@@ -1682,7 +1682,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-06|USA|Belgium": {
       "num": 94,
@@ -1700,7 +1700,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-07|Argentina|Egypt": {
       "num": 95,
@@ -1718,7 +1718,7 @@
       ],
       "pens": null,
       "status": "finished",
-      "source": "live"
+      "source": "openfootball"
     },
     "2026-07-07|Switzerland|Colombia": {
       "num": 96,

--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=33"></script>
-  <script src="assets/js/odds.js?v=33"></script>
-  <script src="assets/js/data.js?v=33"></script>
-  <script src="assets/js/app.js?v=33"></script>
+  <script src="assets/js/scoring.js?v=34"></script>
+  <script src="assets/js/odds.js?v=34"></script>
+  <script src="assets/js/data.js?v=34"></script>
+  <script src="assets/js/app.js?v=34"></script>
 </body>
 </html>

--- a/scripts/fetch_results.py
+++ b/scripts/fetch_results.py
@@ -95,8 +95,10 @@ def normalize_openfootball(data):
         if not (home and away and date):
             continue
         score = m.get("score") or {}
-        ft = score.get("ft")
-        pen = score.get("p")  # penalty shootout result, when a KO match is decided on pens
+        et = score.get("et")           # extra-time final (when a KO match goes to ET)
+        ft = score.get("ft")           # score at 90'
+        final = et if et and len(et) == 2 else ft  # decisive score to display
+        pen = score.get("p")           # penalty shootout result, if it went to pens
         key = f"{date}|{home}|{away}"
         out[key] = {
             "num": m.get("num"),  # FIFA match number (drives the knockout bracket tree)
@@ -108,9 +110,9 @@ def normalize_openfootball(data):
             "group": m.get("group"),
             "round": m.get("round"),
             "ground": m.get("ground"),
-            "score": [ft[0], ft[1]] if ft and len(ft) == 2 else None,
+            "score": [final[0], final[1]] if final and len(final) == 2 else None,
             "pens": [pen[0], pen[1]] if pen and len(pen) == 2 else None,
-            "status": "finished" if ft and len(ft) == 2 else "scheduled",
+            "status": "finished" if final and len(final) == 2 else "scheduled",
             "source": "openfootball",
         }
     return out


### PR DESCRIPTION
Fixes "the page isn't updating / I can't see who won" (e.g. Egypt–Australia, Spain–Portugal).

**Root cause:** the browser only read the committed `results.json` (refreshed by the scheduled Action, which lags) and never consulted the openfootball feed unless that file failed entirely — so finished results and winners didn't show until the Action committed.

**Fixes**
- The client now overlays the **openfootball feed on every refresh**, joined by **FIFA match number** (works even when a committed KO match still shows a `W83` code). openfootball is CORS-enabled and authoritative for finished matches, so results/winners appear immediately regardless of the Action's cadence. It also fills in resolved knockout teams.
- Overlay order: openfootball (finished results + resolved teams) → ESPN/worldcup26 (live in-play) on top.
- **Extra-time bug:** matches decided in extra time were showing the 90' score (e.g. Argentina read `1-1` instead of `3-2`). We now use the `et` score as the decisive result across `fetch_results.py` and `data.js`.
- Regenerated `data/results.json` to the current state (R32 + most of R16 done).

`index.html`: cache-bust `v33` → `v34`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_