### PR TITLE
Real OddsPapi odds wired into the Odds tab (1X2 + O/U 2.5)

### DIFF
--- a/.github/workflows/update-odds.yml
+++ b/.github/workflows/update-odds.yml
@@ -35,8 +35,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if ! git diff --quiet -- data/odds.json; then
-            git add data/odds.json
+          git add data/odds.json
+          # `git diff --quiet` misses untracked files, so check the index instead
+          # (this file was never committed before, so the old check silently no-op'd).
+          if ! git diff --cached --quiet -- data/odds.json; then
             git commit -m "chore: update odds $(date -u +%FT%TZ)"
             git push
           else

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -262,6 +262,10 @@ body > * { position: relative; z-index: 1; }
 .ochip .ol { font-size: 0.7rem; color: var(--muted); }
 .ochip b { font-size: 1.05rem; color: var(--gold); }
 .ochip i { font-size: 0.68rem; color: var(--muted); font-style: normal; }
+.ochip.real { border-color: #3fae5a; background: rgba(63, 174, 90, 0.12); }
+.ochip.real b { color: #6fe08f; }
+.badge.real-odds { display: inline-block; margin: 2px 0 4px; padding: 2px 8px; border-radius: 999px;
+  font-size: 0.68rem; font-weight: 700; background: rgba(63, 174, 90, 0.18); color: #6fe08f; border: 1px solid #3fae5a; }
 
 .foot { text-align: center; padding: 20px; color: var(--muted); font-size: 0.75rem; }
 .foot a { color: var(--accent); }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -138,7 +138,7 @@
     return box;
   }
 
-  let state = { bets: null, results: null, teams: {}, ratings: {}, view: "eliminatorias", player: null, countLive: true, elo: {} };
+  let state = { bets: null, results: null, teams: {}, ratings: {}, view: "eliminatorias", player: null, countLive: true, elo: {}, realOdds: {} };
 
   const $ = (sel, root = document) => root.querySelector(sel);
   const el = (tag, cls, html) => {
@@ -753,14 +753,15 @@
 
     // How-to-read panel (top)
     wrap.appendChild(el("div", "oddshelp",
-      `<p class="ohb">⚠️ <strong>Cuotas estimadas — NO son de casa de apuestas.</strong></p>
+      `<p class="ohb">⚠️ <strong>Cuotas estimadas por un modelo — salvo donde diga 🟢 Cuotas reales.</strong></p>
        <p>Cómo leerlas (cuota decimal estilo momio europeo): si apuestas $100 a una cuota de
-       <b>2.00</b>, recibes $200 (ganancia $100). Cuanto <b>más baja</b> la cuota, más probable según el modelo.
-       El <b>%</b> es la probabilidad estimada.</p>
+       <b>2.00</b>, recibes $200 (ganancia $100). Cuanto <b>más baja</b> la cuota, más probable.
+       El <b>%</b> es la probabilidad implícita.</p>
        <ul class="ohl">
          <li><b>1X2</b> — resultado: gana <b>Local</b>, <b>Empate</b> o gana <b>Visitante</b>.</li>
          <li><b>Total 2.5</b> — <b>Más</b> = 3+ goles en el partido; <b>Menos</b> = 2 o menos.</li>
-         <li><b>Marcador más probable</b> — los 3 marcadores con mayor probabilidad.</li>
+         <li><b>Marcador más probable</b> — los 3 marcadores con mayor probabilidad (siempre estimado por el modelo).</li>
+         <li>🟢 <b>Cuotas reales</b> — 1X2 y Total 2.5 vienen de una casa de apuestas real (vía OddsPapi) cuando el partido ya está definido y listado.</li>
        </ul>`));
 
     // Title Pie — probability of being crowned champion (full-tournament sim).
@@ -803,10 +804,24 @@
       }
       const od = Odds.matchOdds({ lh, la, curH, curA, remFrac });
 
+      // Real bookmaker odds (OddsPapi), when this match is covered — pre-match
+      // only (once live, the model's minute-adjusted estimate is more relevant).
+      const ro = m.status === "scheduled" ? state.realOdds[`${(m.home || "").toLowerCase()}|${(m.away || "").toLowerCase()}`] : null;
+
       if (m.date !== lastDay) { lastDay = m.date; list.appendChild(el("h3", "dayhdr", fmtDay(m.date))); }
 
       const chip = (label, p) =>
         `<span class="ochip">${label ? `<span class="ol">${label}</span>` : ""}<b>${dec(p).toFixed(2)}</b><i>${pct(p)}%</i></span>`;
+      const chipReal = (label, decVal, pctVal) =>
+        `<span class="ochip real">${label ? `<span class="ol">${label}</span>` : ""}<b>${decVal.toFixed(2)}</b><i>${pctVal}%</i></span>`;
+      const row1x2 = ro
+        ? `${chipReal("Local", ro.dec1, ro.pct1)}${chipReal("Empate", ro.decX, ro.pctX)}${chipReal("Visit.", ro.dec2, ro.pct2)}`
+        : `${chip("Local", od.p1)}${chip("Empate", od.pX)}${chip("Visit.", od.p2)}`;
+      const rowOU = ro && ro.decOver != null
+        ? `${chipReal("Más", ro.decOver, ro.pctOver)}${chipReal("Menos", ro.decUnder, ro.pctUnder)}`
+        : `${chip("Más", od.over)}${chip("Menos", od.under)}`;
+      const realBadge = ro ? `<span class="badge real-odds">🟢 Cuotas reales${ro.bookmaker ? " · " + ro.bookmaker : ""}</span>` : "";
+
       const card = el("div", "oddscard");
       card.innerHTML = `
         <div class="mhead">
@@ -814,10 +829,11 @@
           <span class="mtime">${fmtKickoffTime(m)}</span>${statusBadge(m)}
         </div>
         <div class="oteams">${koTeamHTML(m.home)}<span class="ovs">${m.score ? m.score[0] + "–" + m.score[1] : "vs"}</span>${koTeamHTML(m.away)}</div>
+        ${realBadge}
         <div class="omkt"><div class="omh">Resultado (1X2)</div>
-          <div class="orow">${chip("Local", od.p1)}${chip("Empate", od.pX)}${chip("Visit.", od.p2)}</div></div>
+          <div class="orow">${row1x2}</div></div>
         <div class="omkt"><div class="omh">Total de goles 2.5</div>
-          <div class="orow">${chip("Más", od.over)}${chip("Menos", od.under)}</div></div>
+          <div class="orow">${rowOU}</div></div>
         <div class="omkt"><div class="omh">Marcador más probable</div>
           <div class="orow">${od.scores.map((s) => `<span class="ochip"><b>${s.s}</b><i>${pct(s.p)}%</i></span>`).join("")}</div></div>`;
       list.appendChild(card);
@@ -862,7 +878,7 @@
   async function refresh() {
     try {
       const d = await DataLayer.load();
-      state.bets = d.bets; state.results = d.results; state.teams = d.teams; state.ratings = d.ratings || {}; state.elo = d.elo || {};
+      state.bets = d.bets; state.results = d.results; state.teams = d.teams; state.ratings = d.ratings || {}; state.elo = d.elo || {}; state.realOdds = d.realOdds || {};
       render(); // paint committed data immediately (fast, same-origin only)
     } catch (e) {
       console.error(e);

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -283,8 +283,16 @@
     // Elo power ranking (drives the Title Pie / tournament sim).
     let elo = {};
     try { elo = await getJSON("data/team-elo.json"); } catch (e) { /* ignore */ }
+    // Real bookmaker odds (OddsPapi, fetched server-side by a GitHub Action).
+    // Optional: when present, the Odds tab prefers these over the model estimate
+    // for matches it covers. Keyed by "home team|away team" (lowercase).
+    let realOdds = {};
+    try {
+      const ro = await getJSON("data/odds.json");
+      realOdds = (ro && ro.matches) || {};
+    } catch (e) { /* ignore, purely additive */ }
 
-    return { bets, results, teams, ratings, elo };
+    return { bets, results, teams, ratings, elo, realOdds };
   }
 
   // Overlay live scores onto already-loaded results, then re-apply the clock.

--- a/data/odds.json
+++ b/data/odds.json
@@ -1,0 +1,38 @@
+{
+  "generated_at": "2026-07-17T00:01:36.942030+00:00",
+  "provider": "oddspapi",
+  "matches": {
+    "france|england": {
+      "home": "France",
+      "away": "England",
+      "bookmaker": "pinnacle",
+      "kickoff_utc": "2026-07-18T21:00:00.000Z",
+      "dec1": 1.909,
+      "decX": 3.99,
+      "dec2": 3.85,
+      "pct1": 52,
+      "pctX": 25,
+      "pct2": 26,
+      "decOver": 1.408,
+      "decUnder": 2.9,
+      "pctOver": 71,
+      "pctUnder": 34
+    },
+    "spain|argentina": {
+      "home": "Spain",
+      "away": "Argentina",
+      "bookmaker": "pinnacle",
+      "kickoff_utc": "2026-07-19T19:00:00.000Z",
+      "dec1": 2.29,
+      "decX": 3.07,
+      "dec2": 3.69,
+      "pct1": 44,
+      "pctX": 33,
+      "pct2": 27,
+      "decOver": 2.26,
+      "decUnder": 1.675,
+      "pctOver": 44,
+      "pctUnder": 60
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
       Puntuación: acertar ganador/empate +1, marcador exacto +2 (3 en total).</p>
   </footer>
 
-  <script src="assets/js/scoring.js?v=34"></script>
-  <script src="assets/js/odds.js?v=34"></script>
-  <script src="assets/js/data.js?v=34"></script>
-  <script src="assets/js/app.js?v=34"></script>
+  <script src="assets/js/scoring.js?v=35"></script>
+  <script src="assets/js/odds.js?v=35"></script>
+  <script src="assets/js/data.js?v=35"></script>
+  <script src="assets/js/app.js?v=35"></script>
 </body>
 </html>

--- a/scripts/fetch_odds.py
+++ b/scripts/fetch_odds.py
@@ -28,6 +28,7 @@ OUT = "data/odds.json"
 # and 3rd place (France vs England, Jul 18). Used to find fixtures by team name
 # since the tournamentId filter came back empty on this provider.
 WATCH_TEAMS = ["spain", "argentina", "france", "england"]
+# trigger: re-run now that the workflow actually commits data/odds.json
 
 
 def get(path, **params):

--- a/scripts/fetch_odds.py
+++ b/scripts/fetch_odds.py
@@ -2,13 +2,17 @@
 """Fetch OddsPapi data from the GitHub Action (server-side; no CORS / no
 Cloudflare-to-Cloudflare block) and write data/odds.json.
 
-Phase 1 = DISCOVERY: OddsPapi's exact endpoints for the World Cup aren't known
-yet, so this probes a handful of likely paths and logs their status + a sample.
-Read the Action logs to find the right endpoint, then we lock this down to a
-single call that writes the real odds.
+Phase 2 = TOURNAMENT + FIXTURES DISCOVERY. Phase 1 confirmed the working shape:
+  /tournaments?sportId=10          -> list of tournaments (find "World Cup")
+  /fixtures?sportId=10&tournamentId=X&from=YYYY-MM-DD&to=YYYY-MM-DD  (<=10 days apart)
+  /odds?fixtureId=Y                -> odds for one fixture
+This probes those with real values so we can see the World Cup's tournamentId,
+its remaining fixtures (only the Final + 3rd place remain as of writing), and a
+sample odds payload's market shape. Read the Action logs, then lock this down.
 
 The API key comes from the ODDSPAPI_KEY GitHub *secret* (env var), never the repo.
 """
+import datetime as dt
 import json
 import os
 import sys
@@ -22,6 +26,7 @@ OUT = "data/odds.json"
 
 
 def get(path, **params):
+    params = {k: v for k, v in params.items() if v is not None}
     params["apiKey"] = KEY
     url = BASE + path + "?" + urllib.parse.urlencode(params)
     req = urllib.request.Request(url, headers={
@@ -47,24 +52,61 @@ def main():
     def probe(path, **params):
         st, body = get(path, **params)
         print(f"[probe] {path} {params} -> HTTP {st}", file=sys.stderr)
-        print(f"        sample: {body[:500]}", file=sys.stderr)
-        log.append({"path": path, "params": params, "status": st, "sample": body[:2000]})
+        print(f"        sample: {body[:1500]}", file=sys.stderr)
+        log.append({"path": path, "params": params, "status": st, "sample": body[:4000]})
         return st, body
 
-    # Known to work:
-    probe("/sports")
-    # Discover soccer (sportId 10) structure — competitions/leagues/events/odds:
-    for p in ["/competitions", "/leagues", "/tournaments", "/categories",
-              "/events", "/fixtures", "/odds", "/matches"]:
-        probe(p, sportId=10)
-    # Outrights / "World Cup winner" likely under soccer-specials (sportId 44):
-    probe("/competitions", sportId=44)
-    probe("/events", sportId=44)
+    # 1) Full tournaments list for soccer -> find the World Cup tournamentId.
+    st, body = probe("/tournaments", sportId=10)
+    tournament_id = None
+    if st == 200:
+        try:
+            tournaments = json.loads(body)
+            for t in tournaments:
+                slug = (t.get("tournamentSlug") or "").lower()
+                name = (t.get("tournamentName") or "").lower()
+                if "world-cup" in slug or "world cup" in name:
+                    print(f"[found] {t}", file=sys.stderr)
+                    log.append({"note": "world-cup-candidate", "tournament": t})
+                    if "fifa" in slug or "fifa" in name or tournament_id is None:
+                        tournament_id = t.get("tournamentId")
+        except Exception as e:  # noqa: BLE001
+            print(f"[error] parsing tournaments: {e}", file=sys.stderr)
+
+    # 2) Fixtures for that tournament in a near-term window (today .. +9 days;
+    #    the API caps the range at 10 days). Only the Final + 3rd place remain.
+    today = dt.datetime.now(dt.timezone.utc).date()
+    frm = today.isoformat()
+    to = (today + dt.timedelta(days=9)).isoformat()
+    fixture_ids = []
+    if tournament_id is not None:
+        st, body = probe("/fixtures", sportId=10, tournamentId=tournament_id, **{"from": frm, "to": to})
+        if st == 200:
+            try:
+                fixtures = json.loads(body)
+                for fx in fixtures:
+                    fid = fx.get("fixtureId") or fx.get("id")
+                    if fid is not None:
+                        fixture_ids.append(fid)
+            except Exception as e:  # noqa: BLE001
+                print(f"[error] parsing fixtures: {e}", file=sys.stderr)
+    else:
+        print("[warn] no World Cup tournamentId found in /tournaments", file=sys.stderr)
+
+    # 3) Sample odds for up to 2 fixtures (Final / 3rd place) to see the market shape.
+    for fid in fixture_ids[:2]:
+        probe("/odds", fixtureId=fid)
+
+    # Also probe a generic outrights-style path in case "champion" odds live there.
+    if tournament_id is not None:
+        probe("/outrights", sportId=10, tournamentId=tournament_id)
 
     os.makedirs("data", exist_ok=True)
     with open(OUT, "w", encoding="utf-8") as f:
-        json.dump({"_discovery": True, "probes": log}, f, ensure_ascii=False, indent=2)
-    print(f"Wrote {OUT} (discovery dump, {len(log)} probes).", file=sys.stderr)
+        json.dump({"_discovery": True, "tournament_id": tournament_id,
+                    "fixture_ids": fixture_ids, "probes": log}, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {OUT} (discovery dump, {len(log)} probes, tournamentId={tournament_id}, "
+          f"fixtures={fixture_ids}).", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_odds.py
+++ b/scripts/fetch_odds.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
-"""Fetch OddsPapi data from the GitHub Action (server-side; no CORS / no
-Cloudflare-to-Cloudflare block) and write data/odds.json.
+"""Fetch REAL bookmaker odds from OddsPapi and write a compact data/odds.json.
 
-Phase 6 = FULL SCHEMA DUMP. Confirmed working:
-  tournamentId=16 ("World Cup", the real 2026 tournament on this provider)
-  fixtures: France vs England (3rd place, id1000001653452539, Jul 18)
-            Spain vs Argentina (Final, id1000001653452537, Jul 19)
-  /odds?fixtureId=X -> {..., bookmakerOdds: {<bookmaker>: {markets: {<marketId>:
-    {outcomes: {<outcomeId>: {players: {"0": {price, ...}}}}}}}}}
-This dumps the FULL (untruncated) odds payload for both fixtures plus a compact
-summary (bookmakers x markets x outcome prices) so we can pick a normalized
-market (1X2 / match-winner) and a bookmaker (or an average) for the real UI.
+Runs server-side (GitHub Action) — no CORS / no Cloudflare-to-Cloudflare block.
+Confirmed via discovery (read the Action logs of earlier runs if you need the
+raw exploration):
+  - tournamentId=16 is the real 2026 FIFA World Cup on this provider (its
+    'fifa-world-cup' slug tournament reports 0 fixtures for some reason; the
+    plain 'world-cup' slug is the one with actual fixtures/odds).
+  - Market "101" = 1X2 (outcome 101=home, 102=draw, 103=away) — same IDs across
+    every bookmaker on this aggregator.
+  - Market "1010" = Over/Under 2.5 goals (1010=over, 1011=under) — same deal.
+  - Prefer the 'pinnacle' bookmaker (industry-standard low-margin "sharp" book);
+    fall back to an average of a few major books, else skip that match (the
+    site's model-based estimate is used instead — this is purely additive).
 
 The API key comes from the ODDSPAPI_KEY GitHub *secret* (env var), never the repo.
 """
@@ -27,6 +29,9 @@ KEY = os.environ.get("ODDSPAPI_KEY", "").strip()
 BASE = "https://api.oddspapi.io/v4"
 OUT = "data/odds.json"
 TOURNAMENT_ID = 16  # confirmed: the real (men's senior) 2026 World Cup on this provider
+MARKET_1X2 = "101"
+MARKET_OU25 = "1010"
+PREFERRED_BOOKS = ["pinnacle", "bet365", "williamhill", "betmgm", "caesars", "unibet"]
 
 
 def get(path, **params):
@@ -46,32 +51,79 @@ def get(path, **params):
         return -1, str(e)
 
 
-def summarize(fixture_odds):
-    """bookmaker -> marketId -> [{outcomeId, price}] (first player only)."""
+def call(path, **params):
+    st, body = get(path, **params)
+    print(f"[call] {path} {params} -> HTTP {st}", file=sys.stderr)
+    time.sleep(2.5)  # this provider rate-limits; stay well under it
+    return st, body
+
+
+def market_prices(bookmaker_data, market_id):
+    """{outcomeId: price} for one market, or {} if absent/malformed."""
+    mkt = (bookmaker_data.get("markets") or {}).get(market_id) or {}
     out = {}
-    for bk, bdata in (fixture_odds.get("bookmakerOdds") or {}).items():
-        markets = {}
-        for mkt_id, mkt in (bdata.get("markets") or {}).items():
-            outs = []
-            for out_id, out_data in (mkt.get("outcomes") or {}).items():
-                players = out_data.get("players") or {}
-                p0 = players.get("0") or {}
-                outs.append({"outcomeId": out_id, "price": p0.get("price")})
-            markets[mkt_id] = outs
-        out[bk] = markets
+    for out_id, out_data in (mkt.get("outcomes") or {}).items():
+        p0 = (out_data.get("players") or {}).get("0") or {}
+        price = p0.get("price")
+        if isinstance(price, (int, float)) and price > 1:
+            out[out_id] = price
     return out
+
+
+def pick_book(fixture_odds):
+    """Prefer a known low-margin book; else average across whichever of the
+    preferred list are present; else None (caller skips this fixture)."""
+    books = fixture_odds.get("bookmakerOdds") or {}
+    if "pinnacle" in books:
+        return "pinnacle", books["pinnacle"]
+
+    present = [b for b in PREFERRED_BOOKS if b in books]
+    if not present:
+        return None, None
+
+    avg = {"markets": {MARKET_1X2: {"outcomes": {}}, MARKET_OU25: {"outcomes": {}}}}
+    for market_id in (MARKET_1X2, MARKET_OU25):
+        sums, counts = {}, {}
+        for b in present:
+            for out_id, price in market_prices(books[b], market_id).items():
+                sums[out_id] = sums.get(out_id, 0) + price
+                counts[out_id] = counts.get(out_id, 0) + 1
+        for out_id, total in sums.items():
+            mean_price = total / counts[out_id]
+            avg["markets"][market_id]["outcomes"][out_id] = {"players": {"0": {"price": mean_price}}}
+    return f"average({len(present)} books)", avg
+
+
+def implied_pct(price):
+    return round(100 / price) if price and price > 1 else None
+
+
+def extract_match_odds(fixture_odds):
+    book_label, book_data = pick_book(fixture_odds)
+    if not book_data:
+        return None, None
+
+    m1x2 = market_prices(book_data, MARKET_1X2)
+    mou = market_prices(book_data, MARKET_OU25)
+    if not (m1x2.get("101") and m1x2.get("102") and m1x2.get("103")):
+        return None, None  # need a complete 1X2 to be useful
+
+    result = {
+        "dec1": m1x2["101"], "decX": m1x2["102"], "dec2": m1x2["103"],
+        "pct1": implied_pct(m1x2["101"]), "pctX": implied_pct(m1x2["102"]), "pct2": implied_pct(m1x2["103"]),
+    }
+    if mou.get("1010") and mou.get("1011"):
+        result.update({
+            "decOver": mou["1010"], "decUnder": mou["1011"],
+            "pctOver": implied_pct(mou["1010"]), "pctUnder": implied_pct(mou["1011"]),
+        })
+    return book_label, result
 
 
 def main():
     if not KEY:
         print("ERROR: ODDSPAPI_KEY secret not set on the repo.", file=sys.stderr)
         sys.exit(1)
-
-    def call(path, **params):
-        st, body = get(path, **params)
-        print(f"[call] {path} {params} -> HTTP {st}", file=sys.stderr)
-        time.sleep(2.5)
-        return st, body
 
     today = dt.datetime.now(dt.timezone.utc).date()
     frm, to = today.isoformat(), (today + dt.timedelta(days=9)).isoformat()
@@ -80,28 +132,43 @@ def main():
     fixtures = json.loads(body) if st == 200 else []
     print(f"[info] {len(fixtures)} fixtures for tournamentId={TOURNAMENT_ID}", file=sys.stderr)
 
-    dump = {"_debug": True, "tournament_id": TOURNAMENT_ID, "fixtures": [], "odds_raw": {}, "summary": {}}
+    matches = {}
     for fx in fixtures:
         fid = fx.get("fixtureId")
-        dump["fixtures"].append({
-            "fixtureId": fid, "home": fx.get("participant1Name"), "away": fx.get("participant2Name"),
-            "startTime": fx.get("startTime"), "round": fx.get("tournamentName"),
-        })
+        home, away = fx.get("participant1Name"), fx.get("participant2Name")
+        if not (fid and home and away):
+            continue
         st, body = call("/odds", fixtureId=fid)
         if st != 200:
             continue
-        odds = json.loads(body)
-        dump["odds_raw"][fid] = odds  # FULL untruncated payload
-        summ = summarize(odds)
-        dump["summary"][fid] = summ
-        print(f"[summary] fixture {fid} bookmakers: {list(summ.keys())}", file=sys.stderr)
-        for bk, mkts in summ.items():
-            print(f"  [{bk}] markets: {list(mkts.keys())}", file=sys.stderr)
+        try:
+            fixture_odds = json.loads(body)
+        except Exception as e:  # noqa: BLE001
+            print(f"[error] parsing odds for {fid}: {e}", file=sys.stderr)
+            continue
 
+        book_label, odds = extract_match_odds(fixture_odds)
+        if not odds:
+            print(f"[skip] no usable 1X2 for {home} vs {away}", file=sys.stderr)
+            continue
+
+        key = f"{home.strip().lower()}|{away.strip().lower()}"
+        matches[key] = {
+            "home": home, "away": away, "bookmaker": book_label,
+            "kickoff_utc": fx.get("startTime"), **odds,
+        }
+        print(f"[ok] {home} vs {away} <- {book_label}: 1={odds['dec1']} X={odds['decX']} 2={odds['dec2']}",
+              file=sys.stderr)
+
+    payload = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "provider": "oddspapi",
+        "matches": matches,
+    }
     os.makedirs("data", exist_ok=True)
     with open(OUT, "w", encoding="utf-8") as f:
-        json.dump(dump, f, ensure_ascii=False, indent=2)
-    print(f"Wrote {OUT} (full schema dump, {len(fixtures)} fixtures).", file=sys.stderr)
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {OUT}: {len(matches)} matches with real odds.", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_odds.py
+++ b/scripts/fetch_odds.py
@@ -2,13 +2,15 @@
 """Fetch OddsPapi data from the GitHub Action (server-side; no CORS / no
 Cloudflare-to-Cloudflare block) and write data/odds.json.
 
-Phase 2 = TOURNAMENT + FIXTURES DISCOVERY. Phase 1 confirmed the working shape:
-  /tournaments?sportId=10          -> list of tournaments (find "World Cup")
-  /fixtures?sportId=10&tournamentId=X&from=YYYY-MM-DD&to=YYYY-MM-DD  (<=10 days apart)
-  /odds?fixtureId=Y                -> odds for one fixture
-This probes those with real values so we can see the World Cup's tournamentId,
-its remaining fixtures (only the Final + 3rd place remain as of writing), and a
-sample odds payload's market shape. Read the Action logs, then lock this down.
+Phase 6 = FULL SCHEMA DUMP. Confirmed working:
+  tournamentId=16 ("World Cup", the real 2026 tournament on this provider)
+  fixtures: France vs England (3rd place, id1000001653452539, Jul 18)
+            Spain vs Argentina (Final, id1000001653452537, Jul 19)
+  /odds?fixtureId=X -> {..., bookmakerOdds: {<bookmaker>: {markets: {<marketId>:
+    {outcomes: {<outcomeId>: {players: {"0": {price, ...}}}}}}}}}
+This dumps the FULL (untruncated) odds payload for both fixtures plus a compact
+summary (bookmakers x markets x outcome prices) so we can pick a normalized
+market (1X2 / match-winner) and a bookmaker (or an average) for the real UI.
 
 The API key comes from the ODDSPAPI_KEY GitHub *secret* (env var), never the repo.
 """
@@ -24,11 +26,7 @@ import urllib.request
 KEY = os.environ.get("ODDSPAPI_KEY", "").strip()
 BASE = "https://api.oddspapi.io/v4"
 OUT = "data/odds.json"
-# The remaining real matches (as of writing): Final (Spain vs Argentina, Jul 19)
-# and 3rd place (France vs England, Jul 18). Used to find fixtures by team name
-# since the tournamentId filter came back empty on this provider.
-WATCH_TEAMS = ["spain", "argentina", "france", "england"]
-# trigger: re-run now that the workflow actually commits data/odds.json
+TOURNAMENT_ID = 16  # confirmed: the real (men's senior) 2026 World Cup on this provider
 
 
 def get(path, **params):
@@ -48,110 +46,62 @@ def get(path, **params):
         return -1, str(e)
 
 
+def summarize(fixture_odds):
+    """bookmaker -> marketId -> [{outcomeId, price}] (first player only)."""
+    out = {}
+    for bk, bdata in (fixture_odds.get("bookmakerOdds") or {}).items():
+        markets = {}
+        for mkt_id, mkt in (bdata.get("markets") or {}).items():
+            outs = []
+            for out_id, out_data in (mkt.get("outcomes") or {}).items():
+                players = out_data.get("players") or {}
+                p0 = players.get("0") or {}
+                outs.append({"outcomeId": out_id, "price": p0.get("price")})
+            markets[mkt_id] = outs
+        out[bk] = markets
+    return out
+
+
 def main():
     if not KEY:
         print("ERROR: ODDSPAPI_KEY secret not set on the repo.", file=sys.stderr)
         sys.exit(1)
 
-    log = []
-
-    def probe(path, **params):
+    def call(path, **params):
         st, body = get(path, **params)
-        print(f"[probe] {path} {params} -> HTTP {st}", file=sys.stderr)
-        print(f"        sample: {body[:1500]}", file=sys.stderr)
-        log.append({"path": path, "params": params, "status": st, "sample": body[:4000]})
-        time.sleep(2.5)  # this provider rate-limits; stay well under it
+        print(f"[call] {path} {params} -> HTTP {st}", file=sys.stderr)
+        time.sleep(2.5)
         return st, body
 
-    # 1) Full tournaments list for soccer -> find the (men's senior) World Cup
-    #    tournamentId. This provider has BOTH 'fifa-world-cup' (id 24660, but it
-    #    reports 0 upcoming fixtures right now) and a plain 'world-cup' (id 16)
-    #    that reports futureFixtures=2 — exactly our 2 remaining real matches
-    #    (Final + 3rd place). Prefer whichever non-excluded candidate actually
-    #    HAS fixtures; fall back to the exact 'fifa-world-cup' slug.
-    st, body = probe("/tournaments", sportId=10)
-    tournament_id = None
-    fallback_id = None
-    if st == 200:
-        try:
-            tournaments = json.loads(body)
-            EXCLUDE = ("women", "qualif", "virtual", "srl", "u20", "u17", "u23", "novelt", "club")
-            for t in tournaments:
-                slug = (t.get("tournamentSlug") or "").lower()
-                name = (t.get("tournamentName") or "").lower()
-                if "world-cup" not in slug and "world cup" not in name:
-                    continue
-                print(f"[found] {t}", file=sys.stderr)
-                log.append({"note": "world-cup-candidate", "tournament": t})
-                if any(x in slug or x in name for x in EXCLUDE):
-                    continue
-                if (t.get("futureFixtures") or 0) > 0:
-                    tournament_id = t.get("tournamentId")  # has real upcoming matches -> best signal
-                if slug == "fifa-world-cup":
-                    fallback_id = t.get("tournamentId")
-            if tournament_id is None:
-                tournament_id = fallback_id
-        except Exception as e:  # noqa: BLE001
-            print(f"[error] parsing tournaments: {e}", file=sys.stderr)
-
-    # 2) Fixtures for that tournament in a near-term window (today .. +9 days;
-    #    the API caps the range at 10 days). Only the Final + 3rd place remain.
     today = dt.datetime.now(dt.timezone.utc).date()
-    frm = today.isoformat()
-    to = (today + dt.timedelta(days=9)).isoformat()
-    fixture_ids = []
-    if tournament_id is not None:
-        st, body = probe("/fixtures", sportId=10, tournamentId=tournament_id, **{"from": frm, "to": to})
-        if st == 200:
-            try:
-                fixtures = json.loads(body)
-                for fx in fixtures:
-                    fid = fx.get("fixtureId") or fx.get("id")
-                    if fid is not None:
-                        fixture_ids.append(fid)
-            except Exception as e:  # noqa: BLE001
-                print(f"[error] parsing fixtures: {e}", file=sys.stderr)
-    else:
-        print("[warn] no World Cup tournamentId found in /tournaments", file=sys.stderr)
+    frm, to = today.isoformat(), (today + dt.timedelta(days=9)).isoformat()
 
-    # Fallback: the tournamentId filter came back empty (0 fixtures reported by
-    # /tournaments too) — list ALL soccer fixtures in the window and pick out
-    # World Cup ones by name OR by the specific teams still alive (Spain/Argentina
-    # for the Final, France/England for 3rd place), so we can see the real
-    # fixtureId/tournamentId pairing and field shape even if the tournament isn't
-    # labeled "World Cup" the way we expect.
-    if not fixture_ids:
-        st, body = probe("/fixtures", sportId=10, **{"from": frm, "to": to})
-        if st == 200:
-            try:
-                fixtures = json.loads(body)
-                print(f"[info] {len(fixtures)} total soccer fixtures in window", file=sys.stderr)
-                if fixtures:
-                    print(f"[shape] first fixture keys: {list(fixtures[0].keys())}", file=sys.stderr)
-                    print(f"[shape] first fixture: {fixtures[0]}", file=sys.stderr)
-                for fx in fixtures:
-                    blob = json.dumps(fx).lower()
-                    hits = "world cup" in blob or "world-cup" in blob or \
-                        sum(t in blob for t in WATCH_TEAMS) >= 2
-                    if hits:
-                        print(f"[wc-fixture] {fx}", file=sys.stderr)
-                        log.append({"note": "wc-fixture-from-all", "fixture": fx})
-                        fid = fx.get("fixtureId") or fx.get("id")
-                        if fid is not None:
-                            fixture_ids.append(fid)
-            except Exception as e:  # noqa: BLE001
-                print(f"[error] parsing all fixtures: {e}", file=sys.stderr)
+    st, body = call("/fixtures", sportId=10, tournamentId=TOURNAMENT_ID, **{"from": frm, "to": to})
+    fixtures = json.loads(body) if st == 200 else []
+    print(f"[info] {len(fixtures)} fixtures for tournamentId={TOURNAMENT_ID}", file=sys.stderr)
 
-    # 3) Sample odds for up to 2 fixtures (Final / 3rd place) to see the market shape.
-    for fid in fixture_ids[:2]:
-        probe("/odds", fixtureId=fid)
+    dump = {"_debug": True, "tournament_id": TOURNAMENT_ID, "fixtures": [], "odds_raw": {}, "summary": {}}
+    for fx in fixtures:
+        fid = fx.get("fixtureId")
+        dump["fixtures"].append({
+            "fixtureId": fid, "home": fx.get("participant1Name"), "away": fx.get("participant2Name"),
+            "startTime": fx.get("startTime"), "round": fx.get("tournamentName"),
+        })
+        st, body = call("/odds", fixtureId=fid)
+        if st != 200:
+            continue
+        odds = json.loads(body)
+        dump["odds_raw"][fid] = odds  # FULL untruncated payload
+        summ = summarize(odds)
+        dump["summary"][fid] = summ
+        print(f"[summary] fixture {fid} bookmakers: {list(summ.keys())}", file=sys.stderr)
+        for bk, mkts in summ.items():
+            print(f"  [{bk}] markets: {list(mkts.keys())}", file=sys.stderr)
 
     os.makedirs("data", exist_ok=True)
     with open(OUT, "w", encoding="utf-8") as f:
-        json.dump({"_discovery": True, "tournament_id": tournament_id,
-                    "fixture_ids": fixture_ids, "probes": log}, f, ensure_ascii=False, indent=2)
-    print(f"Wrote {OUT} (discovery dump, {len(log)} probes, tournamentId={tournament_id}, "
-          f"fixtures={fixture_ids}).", file=sys.stderr)
+        json.dump(dump, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {OUT} (full schema dump, {len(fixtures)} fixtures).", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_odds.py
+++ b/scripts/fetch_odds.py
@@ -16,6 +16,7 @@ import datetime as dt
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -23,6 +24,10 @@ import urllib.request
 KEY = os.environ.get("ODDSPAPI_KEY", "").strip()
 BASE = "https://api.oddspapi.io/v4"
 OUT = "data/odds.json"
+# The remaining real matches (as of writing): Final (Spain vs Argentina, Jul 19)
+# and 3rd place (France vs England, Jul 18). Used to find fixtures by team name
+# since the tournamentId filter came back empty on this provider.
+WATCH_TEAMS = ["spain", "argentina", "france", "england"]
 
 
 def get(path, **params):
@@ -54,6 +59,7 @@ def main():
         print(f"[probe] {path} {params} -> HTTP {st}", file=sys.stderr)
         print(f"        sample: {body[:1500]}", file=sys.stderr)
         log.append({"path": path, "params": params, "status": st, "sample": body[:4000]})
+        time.sleep(1.2)  # this provider rate-limits; stay well under it
         return st, body
 
     # 1) Full tournaments list for soccer -> find the (men's senior) World Cup
@@ -101,16 +107,24 @@ def main():
 
     # Fallback: the tournamentId filter came back empty (0 fixtures reported by
     # /tournaments too) — list ALL soccer fixtures in the window and pick out
-    # World Cup ones by name, so we can see the real fixtureId/tournamentId pairing.
+    # World Cup ones by name OR by the specific teams still alive (Spain/Argentina
+    # for the Final, France/England for 3rd place), so we can see the real
+    # fixtureId/tournamentId pairing and field shape even if the tournament isn't
+    # labeled "World Cup" the way we expect.
     if not fixture_ids:
         st, body = probe("/fixtures", sportId=10, **{"from": frm, "to": to})
         if st == 200:
             try:
                 fixtures = json.loads(body)
                 print(f"[info] {len(fixtures)} total soccer fixtures in window", file=sys.stderr)
+                if fixtures:
+                    print(f"[shape] first fixture keys: {list(fixtures[0].keys())}", file=sys.stderr)
+                    print(f"[shape] first fixture: {fixtures[0]}", file=sys.stderr)
                 for fx in fixtures:
                     blob = json.dumps(fx).lower()
-                    if "world cup" in blob or "world-cup" in blob:
+                    hits = "world cup" in blob or "world-cup" in blob or \
+                        sum(t in blob for t in WATCH_TEAMS) >= 2
+                    if hits:
                         print(f"[wc-fixture] {fx}", file=sys.stderr)
                         log.append({"note": "wc-fixture-from-all", "fixture": fx})
                         fid = fx.get("fixtureId") or fx.get("id")

--- a/scripts/fetch_odds.py
+++ b/scripts/fetch_odds.py
@@ -59,18 +59,22 @@ def main():
         print(f"[probe] {path} {params} -> HTTP {st}", file=sys.stderr)
         print(f"        sample: {body[:1500]}", file=sys.stderr)
         log.append({"path": path, "params": params, "status": st, "sample": body[:4000]})
-        time.sleep(1.2)  # this provider rate-limits; stay well under it
+        time.sleep(2.5)  # this provider rate-limits; stay well under it
         return st, body
 
     # 1) Full tournaments list for soccer -> find the (men's senior) World Cup
-    #    tournamentId. Exact slug match wins; avoid women's/qualifiers/virtual/SRL
-    #    variants that also contain "world-cup".
+    #    tournamentId. This provider has BOTH 'fifa-world-cup' (id 24660, but it
+    #    reports 0 upcoming fixtures right now) and a plain 'world-cup' (id 16)
+    #    that reports futureFixtures=2 — exactly our 2 remaining real matches
+    #    (Final + 3rd place). Prefer whichever non-excluded candidate actually
+    #    HAS fixtures; fall back to the exact 'fifa-world-cup' slug.
     st, body = probe("/tournaments", sportId=10)
     tournament_id = None
+    fallback_id = None
     if st == 200:
         try:
             tournaments = json.loads(body)
-            EXCLUDE = ("women", "qualif", "virtual", "srl", "u20", "u17", "u23", "novelt")
+            EXCLUDE = ("women", "qualif", "virtual", "srl", "u20", "u17", "u23", "novelt", "club")
             for t in tournaments:
                 slug = (t.get("tournamentSlug") or "").lower()
                 name = (t.get("tournamentName") or "").lower()
@@ -80,8 +84,12 @@ def main():
                 log.append({"note": "world-cup-candidate", "tournament": t})
                 if any(x in slug or x in name for x in EXCLUDE):
                     continue
+                if (t.get("futureFixtures") or 0) > 0:
+                    tournament_id = t.get("tournamentId")  # has real upcoming matches -> best signal
                 if slug == "fifa-world-cup":
-                    tournament_id = t.get("tournamentId")  # exact match, stop overriding
+                    fallback_id = t.get("tournamentId")
+            if tournament_id is None:
+                tournament_id = fallback_id
         except Exception as e:  # noqa: BLE001
             print(f"[error] parsing tournaments: {e}", file=sys.stderr)
 
@@ -136,10 +144,6 @@ def main():
     # 3) Sample odds for up to 2 fixtures (Final / 3rd place) to see the market shape.
     for fid in fixture_ids[:2]:
         probe("/odds", fixtureId=fid)
-
-    # Also probe a generic outrights-style path in case "champion" odds live there.
-    if tournament_id is not None:
-        probe("/outrights", sportId=10, tournamentId=tournament_id)
 
     os.makedirs("data", exist_ok=True)
     with open(OUT, "w", encoding="utf-8") as f:

--- a/scripts/fetch_odds.py
+++ b/scripts/fetch_odds.py
@@ -56,20 +56,26 @@ def main():
         log.append({"path": path, "params": params, "status": st, "sample": body[:4000]})
         return st, body
 
-    # 1) Full tournaments list for soccer -> find the World Cup tournamentId.
+    # 1) Full tournaments list for soccer -> find the (men's senior) World Cup
+    #    tournamentId. Exact slug match wins; avoid women's/qualifiers/virtual/SRL
+    #    variants that also contain "world-cup".
     st, body = probe("/tournaments", sportId=10)
     tournament_id = None
     if st == 200:
         try:
             tournaments = json.loads(body)
+            EXCLUDE = ("women", "qualif", "virtual", "srl", "u20", "u17", "u23", "novelt")
             for t in tournaments:
                 slug = (t.get("tournamentSlug") or "").lower()
                 name = (t.get("tournamentName") or "").lower()
-                if "world-cup" in slug or "world cup" in name:
-                    print(f"[found] {t}", file=sys.stderr)
-                    log.append({"note": "world-cup-candidate", "tournament": t})
-                    if "fifa" in slug or "fifa" in name or tournament_id is None:
-                        tournament_id = t.get("tournamentId")
+                if "world-cup" not in slug and "world cup" not in name:
+                    continue
+                print(f"[found] {t}", file=sys.stderr)
+                log.append({"note": "world-cup-candidate", "tournament": t})
+                if any(x in slug or x in name for x in EXCLUDE):
+                    continue
+                if slug == "fifa-world-cup":
+                    tournament_id = t.get("tournamentId")  # exact match, stop overriding
         except Exception as e:  # noqa: BLE001
             print(f"[error] parsing tournaments: {e}", file=sys.stderr)
 
@@ -92,6 +98,26 @@ def main():
                 print(f"[error] parsing fixtures: {e}", file=sys.stderr)
     else:
         print("[warn] no World Cup tournamentId found in /tournaments", file=sys.stderr)
+
+    # Fallback: the tournamentId filter came back empty (0 fixtures reported by
+    # /tournaments too) — list ALL soccer fixtures in the window and pick out
+    # World Cup ones by name, so we can see the real fixtureId/tournamentId pairing.
+    if not fixture_ids:
+        st, body = probe("/fixtures", sportId=10, **{"from": frm, "to": to})
+        if st == 200:
+            try:
+                fixtures = json.loads(body)
+                print(f"[info] {len(fixtures)} total soccer fixtures in window", file=sys.stderr)
+                for fx in fixtures:
+                    blob = json.dumps(fx).lower()
+                    if "world cup" in blob or "world-cup" in blob:
+                        print(f"[wc-fixture] {fx}", file=sys.stderr)
+                        log.append({"note": "wc-fixture-from-all", "fixture": fx})
+                        fid = fx.get("fixtureId") or fx.get("id")
+                        if fid is not None:
+                            fixture_ids.append(fid)
+            except Exception as e:  # noqa: BLE001
+                print(f"[error] parsing all fixtures: {e}", file=sys.stderr)
 
     # 3) Sample odds for up to 2 fixtures (Final / 3rd place) to see the market shape.
     for fid in fixture_ids[:2]:


### PR DESCRIPTION
Connects the free/estimated Odds tab to **real bookmaker odds** for the two remaining matches (3rd place: France–England, Final: Spain–Argentina), using the OddsPapi key added as a repo secret.

**Discovery (server-side, via `.github/workflows/update-odds.yml` on this branch):**
- Confirmed `tournamentId=16` is the real 2026 World Cup on this provider (its literal `fifa-world-cup` slug tournament oddly reports 0 fixtures — `world-cup` is the one with actual games).
- Confirmed normalized market IDs consistent across ~100+ bookmakers: **`101`** = 1X2 (101/102/103 = home/draw/away), **`1010`** = Over/Under 2.5 goals (1010/1011 = over/under).
- Also fixed a real bug found along the way: the workflow's "commit if changed" step used `git diff --quiet`, which **ignores untracked files** — since `data/odds.json` had never been committed, every previous discovery run silently discarded its output. Now stages the file first.

**Production `scripts/fetch_odds.py`:**
- Fetches World Cup fixtures + odds per fixture, prefers **pinnacle** (low-margin reference book) with a fallback to an average of major books, and writes a compact `data/odds.json` (~1KB) keyed by team-name pair.

**Frontend (`data.js` + `app.js`):**
- `data.js` loads `data/odds.json` best-effort (purely additive — missing/failed load just falls back to the existing model).
- `renderOdds()` now shows a **🟢 Cuotas reales · pinnacle** badge and uses the real decimal odds + implied % for 1X2 and Total 2.5 on any pre-match fixture OddsPapi covers; live matches and everything else keep using the in-house Poisson model. "Marcador más probable" stays model-based (no real correct-score market fetched).
- Help panel updated to explain the green badge.

`index.html`: cache-bust `v34` → `v35`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unn577uAL3gw5BLBVsmvvL)_